### PR TITLE
Install mini-css-extract-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Route Manager Queue for adding routes efficiently and with an optional priority - @grimasod (#3540)
 - Added tests for cart module actions - @andrzejewsky (#3023)
 - Fixed a problem with type changes in the state when extending a store - @resubaka (#3618)
+- Install mini-css-extract-plugin - @DnD-Waxime (#3501)
 
 ### Fixed
 

--- a/core/build/webpack.base.config.ts
+++ b/core/build/webpack.base.config.ts
@@ -26,6 +26,7 @@ const themedIndex = path.join(themeRoot, '/templates/index.template.html')
 const themedIndexMinimal = path.join(themeRoot, '/templates/index.minimal.template.html')
 const themedIndexBasic = path.join(themeRoot, '/templates/index.basic.template.html')
 const themedIndexAmp = path.join(themeRoot, '/templates/index.amp.template.html')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const csvDirectories = [
   path.resolve(__dirname, '../../node_modules/@vue-storefront/i18n/resource/i18n/')
@@ -94,7 +95,8 @@ export default {
     new webpack.DefinePlugin({
       'process.env.__APPVERSION__': JSON.stringify(require('../../package.json').version),
       'process.env.__BUILDTIME__': JSON.stringify(dayjs().format('YYYY-MM-DD HH:mm:ss'))
-    })
+    }),
+    new MiniCssExtractPlugin()
   ],
   devtool: 'source-map',
   entry: {
@@ -214,6 +216,19 @@ export default {
         test: /\.(graphqls|gql)$/,
         exclude: /node_modules/,
         loader: ['graphql-tag/loader']
+      },
+      {
+        test: /\.sass$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: '../',
+              hmr: process.env.NODE_ENV === 'development'
+            }
+          },
+          'sass-loader'
+        ]
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -50,10 +50,7 @@
   },
   "lint-staged": {
     "*.{js,vue,ts}": "eslint",
-    "**/i18n/*.csv": [
-      "node ./core/scripts/utils/sort-translations.js",
-      "git add"
-    ]
+    "**/i18n/*.csv": ["node ./core/scripts/utils/sort-translations.js", "git add"]
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
   },
   "lint-staged": {
     "*.{js,vue,ts}": "eslint",
-    "**/i18n/*.csv": ["node ./core/scripts/utils/sort-translations.js", "git add"]
+    "**/i18n/*.csv": [
+      "node ./core/scripts/utils/sort-translations.js",
+      "git add"
+    ]
   },
   "husky": {
     "hooks": {
@@ -78,6 +81,7 @@
     "js-sha3": "^0.8.0",
     "localforage": "^1.7.2",
     "magento2-rest-client": "github:DivanteLtd/magento2-rest-client",
+    "mini-css-extract-plugin": "^0.8.0",
     "ms": "^2.1.2",
     "pm2": "^2.10.4",
     "proxy-polyfill": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9549,6 +9549,16 @@ mini-css-extract-plugin@0.4.1:
     loader-utils "^1.1.0"
     webpack-sources "^1.1.0"
 
+mini-css-extract-plugin@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz#81d41ec4fe58c713a96ad7c723cdb2d0bd4d70e1"
+  integrity sha512-MNpRGbNA52q6U92i0qbVpQNsgk7LExy41MdAlG84FeytfDOtRIf/mCHdEgG8rpTKOaNKiqUnZdlptF469hxqOw==
+  dependencies:
+    loader-utils "^1.1.0"
+    normalize-url "1.9.1"
+    schema-utils "^1.0.0"
+    webpack-sources "^1.1.0"
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -10000,7 +10010,7 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
-normalize-url@^1.4.0:
+normalize-url@1.9.1, normalize-url@^1.4.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
   dependencies:


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

[#3501](https://github.com/DivanteLtd/vue-storefront/issues/3501)

closes #

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Basic installation of the mini-css-extract-plugin.

I tried it on my vsf local project (connect to demo api: https://test.storefrontcloud.io/). Find bellow the results of the speed results in seconds :
- **Without the plugin**
   - Homepage :  ~1,8s
   - Catalog page (men view all) :  ~5,12s
   - Product page :  ~4,46s
- **With the plugin**
   - Homepage :  ~2,04s
   - Catalog page (men view all) :  ~4,08s
   - Product page :  ~3,7s

Consider that i haven't configure deeply the plugin. Maybe it can be better with some research.

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

