### PR TITLE
Next: Skip personal details when already logged in

### DIFF
--- a/packages/core/theme-module/theme/pages/Checkout.vue
+++ b/packages/core/theme-module/theme/pages/Checkout.vue
@@ -28,6 +28,7 @@ import { SfSteps, SfButton } from '@storefront-ui/vue';
 import CartPreview from '~/components/checkout/CartPreview';
 import OrderReview from '~/components/checkout/OrderReview';
 import { ref } from '@vue/composition-api';
+import { useUser } from '<%= options.composables %>';
 
 const STEPS = [
   { name: 'personal-details',
@@ -55,13 +56,22 @@ export default {
   setup(props, context) {
     const showCartPreview = ref(true);
     const currentStep = ref(0);
+    const { isAuthenticated } = useUser();
 
     const handleShowReview = () => {
       showCartPreview.value = false;
     };
 
     const updateStep = (next) => {
-      currentStep.value = next;
+      if (next == 0 && isAuthenticated.value) {
+        if (currentStep.value == STEPS[1]) {
+          context.root.$router.push('/');
+        } else {
+          next++;
+          context.root.$router.push(STEPS[next].name);
+        }
+      } else 
+        currentStep.value = next;
     };
 
     const handleNextStep = (nextStep) => {


### PR DESCRIPTION
### Short Description and Why It's Useful
This pull requests skips the first page of the checkout process (the personal details) when already logged in. This page contains first name, last name and email, and lets the user login or register. Which all are things that make no sense for logged in users.

### Which Environment This Relates To
* [x] Next 
### Upgrade Notes and Changelog
* [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

* [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)



┆Issue is synchronized with this [Jira Story](https://vsf.atlassian.net/browse/NEXT-86) by [Unito](https://www.unito.io/learn-more)
