### PR TITLE
Next: Fixes watch everything that affects the category

### DIFF
--- a/packages/core/theme-module/theme/pages/Category.vue
+++ b/packages/core/theme-module/theme/pages/Category.vue
@@ -320,6 +320,7 @@ export default {
     const itemsPerPage = ref(parseInt(query.items, 10) || perPageOptions[0]);
     const filters = ref(null);
     const isGridView = ref(query.gridview != "false");
+    const sortBy = ref(query.sort || 'price-up');
 
     const productsSearchParams = computed(() => ({
       catId: (categories.value[0] || {}).id,
@@ -342,6 +343,7 @@ export default {
           ...context.root.$route.query,
           gridview: isGridView.value ? undefined : "false",
           ...getFiltersForUrl(filters.value),
+          sort: sortBy.value,
           items: itemsPerPage.value !== perPageOptions[0] ? itemsPerPage.value : undefined
         }});
         await productsSearch(productsSearchParams.value);
@@ -354,7 +356,6 @@ export default {
 
     const isCategorySelected = (slug) => slug === (categories.value && categories.value[0].slug);
 
-    const sortBy = ref('price-up');
     const isFilterSidebarOpen = ref(false);
 
     function toggleWishlist(index) {

--- a/packages/core/theme-module/theme/pages/Category.vue
+++ b/packages/core/theme-module/theme/pages/Category.vue
@@ -325,7 +325,8 @@ export default {
       catId: (categories.value[0] || {}).id,
       page: currentPage.value,
       perPage: itemsPerPage.value,
-      filters: filters.value
+      filters: filters.value,
+      sortBy: sortBy.value
     }));
 
     onSSR(async () => {

--- a/packages/core/theme-module/theme/pages/Category.vue
+++ b/packages/core/theme-module/theme/pages/Category.vue
@@ -316,9 +316,10 @@ export default {
       availableFilters
     } = useProduct('categoryProducts');
 
-    const currentPage = ref(parseInt(query.page, 10) || 1);
+    const currentPage = computed(() => parseInt(query.page, 10) || 1);
     const itemsPerPage = ref(parseInt(query.items, 10) || perPageOptions[0]);
     const filters = ref(null);
+    const isGridView = ref(query.gridview != "false");
 
     const productsSearchParams = computed(() => ({
       catId: (categories.value[0] || {}).id,
@@ -334,14 +335,16 @@ export default {
       await productsSearch(productsSearchParams.value);
     });
 
-    watch([itemsPerPage, filters], () => {
+    watch([currentPage, itemsPerPage, filters, sortBy, isGridView], async () => {
       if (categories.value.length) {
-        productsSearch(productsSearchParams.value);
         context.root.$router.push({ query: {
           ...context.root.$route.query,
+          gridview: isGridView.value ? undefined : "false",
           ...getFiltersForUrl(filters.value),
           items: itemsPerPage.value !== perPageOptions[0] ? itemsPerPage.value : undefined
         }});
+        await productsSearch(productsSearchParams.value);
+        context.root.$scrollTo(context.root.$el, 2000);
       }
     }, { deep: true });
 
@@ -351,7 +354,6 @@ export default {
     const isCategorySelected = (slug) => slug === (categories.value && categories.value[0].slug);
 
     const sortBy = ref('price-up');
-    const isGridView = ref(true);
     const isFilterSidebarOpen = ref(false);
 
     function toggleWishlist(index) {


### PR DESCRIPTION
This fixes #4375 the watch to watch everything relevant for the category:
currentPage, itemsPerPage, filters, sortBy, isGridView, and retains it in the url.

### Short Description and Why It's Useful

Since the SFPagination changes, the currentPage is done via router pushes, instead of click events, but the page was never re-requested to show the next page. This fixes that, and also retains and passes sorting and retains the gridview mode (only includes it when unsetting gridview).

### Which Environment This Relates To

- [x] Next.

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

