### PR TITLE
Next: Toggle cart, wishlist and account from bottom navigation (mobile)

### DIFF
--- a/packages/core/theme-module/theme/components/BottomNavigation.vue
+++ b/packages/core/theme-module/theme/components/BottomNavigation.vue
@@ -5,12 +5,13 @@
       <SfBottomNavigationItem :class="$route.path == '/' ? 'sf-bottom-navigation__item--active' : ''" icon="home" size="20px" label="Home"/>
     </nuxt-link>
     <SfBottomNavigationItem data-cy="bottom-navigation-url_menu" icon="menu" size="20px" label="Menu"/>
-    <SfBottomNavigationItem data-cy="bottom-navigation-url_wishlist" icon="heart" size="20px" label="Wishlist"/>
-    <SfBottomNavigationItem data-cy="bottom-navigation-url_account" icon="profile" size="20px" label="Account"/>
+    <SfBottomNavigationItem data-cy="bottom-navigation-url_wishlist" icon="heart" size="20px" label="Wishlist" @click="toggleWishlistSidebar()" />
+    <SfBottomNavigationItem data-cy="bottom-navigation-url_account" icon="profile" size="20px" label="Account" @click="onAccountClicked()"/>
     <!-- TODO: add logic for label - if on Home then Basket, if on PDC then AddToCart etc. -->
     <SfBottomNavigationItem data-cy="bottom-navigation-url_add-to-cart"
       label="Basket"
       icon="add_to_cart"
+      @click="toggleCartSidebar()"
       >
       <template #icon>
         <SfCircleIcon aria-label="Add to cart">
@@ -28,12 +29,24 @@
 
 <script>
 import { SfBottomNavigation, SfIcon, SfCircleIcon } from '@storefront-ui/vue';
+import uiState from '~/assets/ui-state';
+import { useUser } from '<%= options.composables %>';
+const { toggleCartSidebar, toggleWishlistSidebar, toggleLoginModal } = uiState;
 
 export default {
   components: {
     SfBottomNavigation,
     SfIcon,
     SfCircleIcon
+  },
+  setup(props, { root }) {
+    const { isAuthenticated } = useUser();
+    const onAccountClicked = () => {
+      isAuthenticated && isAuthenticated.value ? root.$router.push('/my-account') : toggleLoginModal();
+    };
+    return {
+      toggleCartSidebar, onAccountClicked, toggleWishlistSidebar
+    }
   }
 };
 </script>


### PR DESCRIPTION
### Short Description and Why It's Useful

This hooks up toggle support for wishlist, cart and account in the bottom bar.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
![afbeelding](https://user-images.githubusercontent.com/238568/82821142-d3e3c900-9ea3-11ea-90b9-989233e66fb2.png)

Technically not a visual change, but the last three buttons now work.

### Which Environment This Relates To

- [x] Next version
### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

