### PR TITLE
Next: Fix for SFColor selector.

### DIFF
--- a/packages/core/nuxt-theme-module/theme/pages/Product.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Product.vue
@@ -77,7 +77,7 @@
                 :key="i"
                 :color="color.value"
                 class="product__color"
-                @click="updateFilter({color})"
+                @click="updateFilter({color: color.value})"
               />
             </div>
           </div>


### PR DESCRIPTION

### Related Issues
closes #N/A

### Short Description and Why It's Useful

Using the SFColor selector is currently broken because it tries to convert an object to a string.

- Current behavior: size=S&color=%5Bobject%20Object%5D
- Expected behavior: size=S&color=Beige


### Screenshots of Visual Changes before/after (if There Are Any)
N/A

### Which Environment This Relates To
N/A (next branch)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [ ] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

