### PR TITLE
Next: Applied coupons fixes

### DIFF
--- a/packages/about-you/api-client/package.json
+++ b/packages/about-you/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/about-you-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aboutyou/backbone": "^7.0.0",
-    "@vue-storefront/core": "^2.0.4"
+    "@vue-storefront/core": "^2.0.6"
   },
   "files": [
     "lib/**/*"

--- a/packages/about-you/composables/__tests__/composables/useCart/factoryParams.spec.ts
+++ b/packages/about-you/composables/__tests__/composables/useCart/factoryParams.spec.ts
@@ -27,7 +27,10 @@ describe('[about-you-composables] useCart factoryParams', () => {
 
     (getCart as jest.Mock).mockReturnValueOnce(expectedCart);
 
-    expect(await params.loadCart()).toEqual(expectedCart.basket);
+    expect(await params.loadCart()).toEqual({
+      currentCart: expectedCart.basket,
+      currentCoupon: null
+    });
   });
 
   describe('addToCart', () => {

--- a/packages/about-you/composables/__tests__/composables/useCart/factoryParams.spec.ts
+++ b/packages/about-you/composables/__tests__/composables/useCart/factoryParams.spec.ts
@@ -264,7 +264,7 @@ describe('[about-you-composables] useCart factoryParams', () => {
       packages: []
     };
 
-    expect(params.applyCoupon({ currentCart, coupon: 'foo' })).rejects.toThrow();
+    expect(params.applyCoupon({ currentCart, currentCoupon: 'foo' })).rejects.toThrow();
   });
 
   it('removeCoupon throws error that it\'s not supported', () => {
@@ -276,7 +276,7 @@ describe('[about-you-composables] useCart factoryParams', () => {
       packages: []
     };
 
-    expect(params.removeCoupon({ currentCart, coupon: null })).rejects.toThrow();
+    expect(params.removeCoupon({ currentCart, currentCoupon: null })).rejects.toThrow();
   });
 
   describe('isOnCart', () => {

--- a/packages/about-you/composables/package.json
+++ b/packages/about-you/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/about-you",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
@@ -12,8 +12,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vue-storefront/about-you-api": "^0.1.0",
-    "@vue-storefront/core": "^2.0.4",
+    "@vue-storefront/about-you-api": "^0.1.1",
+    "@vue-storefront/core": "^2.0.6",
     "vue": "^2.6.x"
   },
   "devDependencies": {

--- a/packages/about-you/composables/src/composables/useCart/factoryParams.ts
+++ b/packages/about-you/composables/src/composables/useCart/factoryParams.ts
@@ -38,9 +38,12 @@ const updateQuantity = async ({ product, quantity }) => {
 };
 export const params: UseCartFactoryParams<BasketResponseData, BasketItem, BapiProduct, any> = {
   loadCart: async () => {
-    const basketResponse = await getCart(null, { with: cartParams });
+    const { basket: currentCart } = await getCart(null, { with: cartParams });
 
-    return basketResponse.basket;
+    return {
+      currentCart,
+      currentCoupon: null
+    };
   },
   addToCart: async ({ currentCart, product, quantity }) => {
     const basketItem = getBasketItemByProduct({ currentCart, product });

--- a/packages/about-you/theme/package.json
+++ b/packages/about-you/theme/package.json
@@ -2,7 +2,7 @@
   "name": "@vue-storefront/about-you-theme",
   "description": "My breathtaking Nuxt.js project",
   "author": "Łukasz Romanowicz",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "dev": "nuxt",
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@storefront-ui/vue": "^0.7.17",
-    "@vue-storefront/about-you": "^0.0.3",
-    "@vue-storefront/about-you-api": "^0.1.0",
+    "@vue-storefront/about-you": "^0.0.4",
+    "@vue-storefront/about-you-api": "^0.1.1",
     "@vue-storefront/nuxt": "^0.0.4",
     "@vue-storefront/nuxt-theme": "^0.0.2",
     "cookie-universal-nuxt": "^2.1.3",

--- a/packages/boilerplate/composables/src/composables/useCart/index.ts
+++ b/packages/boilerplate/composables/src/composables/useCart/index.ts
@@ -11,7 +11,10 @@ export const cart: Ref<Cart> = ref(null);
 const params: UseCartFactoryParams<Cart, CartItem, Product, Coupon> = {
   loadCart: async () => {
     console.log('Mocked: loadCart');
-    return {};
+    return {
+      currentCart: null,
+      currentCoupon: null
+    };
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   addToCart: async ({ currentCart, product, quantity }) => {

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/commercetools-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -11,7 +11,7 @@
     "test": "cross-env APP_ENV=test jest --rootDir ."
   },
   "dependencies": {
-    "@vue-storefront/core": "2.0.5",
+    "@vue-storefront/core": "2.0.6",
     "@commercetools/sdk-auth": "^3.0.1",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",

--- a/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
+++ b/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
@@ -3,7 +3,8 @@ import loadCurrentCart from './../../src/useCart/currentCart';
 import {
   addToCart as apiAddToCart,
   removeFromCart as apiRemoveFromCart,
-  updateCartQuantity as apiUpdateCartQuantity
+  updateCartQuantity as apiUpdateCartQuantity,
+  applyCartCoupon as apiApplyCartCoupon
 } from '@vue-storefront/commercetools-api';
 
 jest.mock('./../../src/useCart/currentCart');
@@ -70,15 +71,26 @@ describe('[commercetools-composables] useCart', () => {
   });
 
   it('applies coupon', async () => {
+    const cart = {
+      discountCodes: [
+        'abc'
+      ]
+    };
+
+    apiApplyCartCoupon.mockImplementation(() => ({
+      data: {
+        cart
+      }
+    }));
     const { applyCoupon } = useCart() as any;
     const response = await applyCoupon({ currentCart: 'current cart', coupon: 'X123' });
 
-    expect(response).toEqual({ updatedCart: 'some cart', updatedCoupon: 'X123' });
+    expect(response).toEqual({ updatedCart: cart, updatedCoupon: cart.discountCodes[0] });
   });
 
   it('removes coupon', async () => {
     const { removeCoupon } = useCart() as any;
-    const response = await removeCoupon({ currentCart: 'current cart' });
+    const response = await removeCoupon({ currentCart: 'current cart', coupon: { discountCode: '12' } });
 
     expect(response).toEqual({ updatedCart: 'current cart' });
   });

--- a/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
+++ b/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
@@ -83,14 +83,14 @@ describe('[commercetools-composables] useCart', () => {
       }
     }));
     const { applyCoupon } = useCart() as any;
-    const response = await applyCoupon({ currentCart: 'current cart', coupon: 'X123' });
+    const response = await applyCoupon({ currentCart: 'current cart', currentCoupon: 'X123' });
 
     expect(response).toEqual({ updatedCart: cart, updatedCoupon: cart.discountCodes[0] });
   });
 
   it('removes coupon', async () => {
     const { removeCoupon } = useCart() as any;
-    const response = await removeCoupon({ currentCart: 'current cart', coupon: { discountCode: '12' } });
+    const response = await removeCoupon({ currentCart: 'current cart', currentCoupon: { discountCode: '12' } });
 
     expect(response).toEqual({ updatedCart: 'current cart' });
   });

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/commercetools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -11,8 +11,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vue-storefront/commercetools-api": "0.1.0",
-    "@vue-storefront/core": "2.0.4",
+    "@vue-storefront/commercetools-api": "0.1.1",
+    "@vue-storefront/core": "2.0.6",
     "js-cookie": "^2.2.1",
     "vue": "^2.6.x"
   },

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -42,15 +42,15 @@ const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, any> = {
   clearCart: async ({ currentCart }) => {
     return currentCart;
   },
-  applyCoupon: async ({ currentCart, coupon }) => {
-    const updatedCart = await apiApplyCartCoupon(currentCart, coupon);
+  applyCoupon: async ({ currentCart, currentCoupon }) => {
+    const updatedCart = await apiApplyCartCoupon(currentCart, currentCoupon);
     const updatedCoupon = updatedCart && updatedCart.data && updatedCart.data.cart && Array.isArray(updatedCart.data.cart.discountCodes) && updatedCart.data.cart.discountCodes.length
       ? updatedCart.data.cart.discountCodes[0]
       : null;
     return { updatedCart: updatedCart.data.cart, updatedCoupon };
   },
-  removeCoupon: async ({ currentCart, coupon }) => {
-    const updatedCart = await apiRemoveCartCoupon(currentCart, { id: coupon.discountCode.id, typeId: 'discount-code' });
+  removeCoupon: async ({ currentCart, currentCoupon }) => {
+    const updatedCart = await apiRemoveCartCoupon(currentCart, { id: currentCoupon.discountCode.id, typeId: 'discount-code' });
     return { updatedCart: updatedCart.data.cart };
   },
   isOnCart: ({ currentCart, product }) => {

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -44,7 +44,10 @@ const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, any> = {
   },
   applyCoupon: async ({ currentCart, coupon }) => {
     const updatedCart = await apiApplyCartCoupon(currentCart, coupon);
-    return { updatedCart: updatedCart.data.cart, updatedCoupon: updatedCart.data.cart.discountCodes[0] };
+    const updatedCoupon = updatedCart && updatedCart.data && updatedCart.data.cart && Array.isArray(updatedCart.data.cart.discountCodes) && updatedCart.data.cart.discountCodes.length
+      ? updatedCart.data.cart.discountCodes[0]
+      : null;
+    return { updatedCart: updatedCart.data.cart, updatedCoupon };
   },
   removeCoupon: async ({ currentCart, coupon }) => {
     const updatedCart = await apiRemoveCartCoupon(currentCart, { id: coupon.discountCode.id, typeId: 'discount-code' });

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -15,7 +15,15 @@ const getBasketItemByProduct = ({ currentCart, product }) => {
 
 const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, any> = {
   loadCart: async () => {
-    return await loadCurrentCart();
+    const currentCart = await loadCurrentCart();
+    const currentCoupon = currentCart && Array.isArray(currentCart.discountCodes) && currentCart.discountCodes.length
+      ? currentCart.discountCodes[0]
+      : null;
+
+    return {
+      currentCart,
+      currentCoupon
+    };
   },
   addToCart: async ({ currentCart, product, quantity }) => {
     const updatedCart = await apiAddToCart(currentCart, product, quantity);

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -44,10 +44,10 @@ const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, any> = {
   },
   applyCoupon: async ({ currentCart, coupon }) => {
     const updatedCart = await apiApplyCartCoupon(currentCart, coupon);
-    return { updatedCart: updatedCart.data.cart, updatedCoupon: coupon };
+    return { updatedCart: updatedCart.data.cart, updatedCoupon: updatedCart.data.cart.discountCodes[0] };
   },
   removeCoupon: async ({ currentCart, coupon }) => {
-    const updatedCart = await apiRemoveCartCoupon(currentCart, { id: coupon.discountCode.id, typeId: coupon.discountCode.__typename });
+    const updatedCart = await apiRemoveCartCoupon(currentCart, { id: coupon.discountCode.id, typeId: 'discount-code' });
     return { updatedCart: updatedCart.data.cart };
   },
   isOnCart: ({ currentCart, product }) => {

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -47,7 +47,7 @@ const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, any> = {
     return { updatedCart: updatedCart.data.cart, updatedCoupon: coupon };
   },
   removeCoupon: async ({ currentCart, coupon }) => {
-    const updatedCart = await apiRemoveCartCoupon(currentCart, coupon);
+    const updatedCart = await apiRemoveCartCoupon(currentCart, { id: coupon.discountCode.id, typeId: coupon.discountCode.__typename });
     return { updatedCart: updatedCart.data.cart };
   },
   isOnCart: ({ currentCart, product }) => {

--- a/packages/commercetools/theme/package.json
+++ b/packages/commercetools/theme/package.json
@@ -2,7 +2,7 @@
   "name": "@vue-storefront/commercetools-theme",
   "description": "My breathtaking Nuxt.js project",
   "author": "Filip Rakowski",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@storefront-ui/vue": "^0.7.10",
-    "@vue-storefront/commercetools": "^0.1.0",
+    "@vue-storefront/commercetools": "^0.1.1",
     "@vue-storefront/nuxt": "^0.0.4",
     "@vue-storefront/nuxt-theme": "^0.0.2",
     "cookie-universal-nuxt": "^2.1.3",

--- a/packages/core/core/__tests__/factories/useCartFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/useCartFactory.spec.ts
@@ -154,7 +154,7 @@ describe('[CORE - factories] useCartFactory', () => {
         await applyCoupon('qwerty');
         expect(params.applyCoupon).toHaveBeenCalledWith({
           currentCart: null,
-          coupon: 'qwerty'
+          currentCoupon: 'qwerty'
         });
         expect(cart.value).toEqual({ id: 'mocked_apply_coupon_cart' });
         expect(coupon.value).toEqual('appliedCouponMock');
@@ -167,7 +167,7 @@ describe('[CORE - factories] useCartFactory', () => {
         await removeCoupon();
         expect(params.removeCoupon).toHaveBeenCalledWith({
           currentCart: null,
-          coupon: null
+          currentCoupon: null
         });
         expect(cart.value).toEqual({ id: 'mocked_removed_coupon_cart' });
         expect(coupon.value).toBeNull();

--- a/packages/core/core/__tests__/factories/useCartFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/useCartFactory.spec.ts
@@ -8,7 +8,10 @@ let params: UseCartFactoryParams<any, any, any, any>;
 
 function createComposable() {
   params = {
-    loadCart: jest.fn().mockResolvedValueOnce({ id: 'mocked_cart' }),
+    loadCart: jest.fn().mockResolvedValueOnce({
+      currentCart: { id: 'mocked_cart' },
+      currenCoupon: null
+    }),
     addToCart: jest.fn().mockResolvedValueOnce({ id: 'mocked_added_cart' }),
     removeFromCart: jest
       .fn()

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/core/core/src/factories/useCartFactory.ts
+++ b/packages/core/core/src/factories/useCartFactory.ts
@@ -3,7 +3,7 @@ import { Ref, computed } from '@vue/composition-api';
 import { sharedRef } from '../utils';
 
 export type UseCartFactoryParams<CART, CART_ITEM, PRODUCT, COUPON> = {
-  loadCart: () => Promise<CART>;
+  loadCart: () => Promise<{ currentCart: CART; currentCoupon: COUPON }>;
   addToCart: (params: {
     currentCart: CART;
     product: PRODUCT;
@@ -86,7 +86,9 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
       if (cart.value) return;
 
       loading.value = true;
-      cart.value = await factoryParams.loadCart();
+      const { currentCart, currentCoupon } = await factoryParams.loadCart();
+      cart.value = currentCart;
+      appliedCoupon.value = currentCoupon;
       loading.value = false;
     };
 

--- a/packages/core/core/src/factories/useCartFactory.ts
+++ b/packages/core/core/src/factories/useCartFactory.ts
@@ -21,11 +21,11 @@ export type UseCartFactoryParams<CART, CART_ITEM, PRODUCT, COUPON> = {
   clearCart: (prams: { currentCart: CART }) => Promise<CART>;
   applyCoupon: (params: {
     currentCart: CART;
-    coupon: string;
+    currentCoupon: string;
   }) => Promise<{ updatedCart: CART; updatedCoupon: COUPON }>;
   removeCoupon: (params: {
     currentCart: CART;
-    coupon: COUPON;
+    currentCoupon: COUPON;
   }) => Promise<{ updatedCart: CART }>;
   isOnCart: (params: { currentCart: CART; product: PRODUCT }) => boolean;
 };
@@ -108,12 +108,12 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
       });
     };
 
-    const applyCoupon = async (coupon: string) => {
+    const applyCoupon = async (currentCoupon: string) => {
       try {
         loading.value = true;
         const { updatedCart, updatedCoupon } = await factoryParams.applyCoupon({
           currentCart: cart.value,
-          coupon
+          currentCoupon
         });
         cart.value = updatedCart;
         appliedCoupon.value = updatedCoupon;
@@ -127,7 +127,7 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
         loading.value = true;
         const { updatedCart } = await factoryParams.removeCoupon({
           currentCart: cart.value,
-          coupon: appliedCoupon.value
+          currentCoupon: appliedCoupon.value
         });
         cart.value = updatedCart;
         appliedCoupon.value = null;

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -9,3 +9,5 @@
 
 * **factories**: refactored setup using apiClientFactory (#4777)
 * **factories**: updated return signature of loadCart ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
+* **factories**: updated call arguments of applyCoupon ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
+* **factories**: updated call arguments of removeCoupon ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -8,6 +8,4 @@
 ### Changes
 
 * **factories**: refactored setup using apiClientFactory (#4777)
-* **factories**: updated return signature of loadCart ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
-* **factories**: updated call arguments of applyCoupon ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
-* **factories**: updated call arguments of removeCoupon ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
+* **factories**: updated return signature of loadCart, updated call arguments of applyCoupon, removeCoupon, changed coupon to currentCoupon in singatures ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -3,7 +3,7 @@
 ## 2.1.0 (not released)
 
 ### Breaking changes
-* **factories**: UseCartFactoryParam loadCart returns object with currentCart & currentCoupon ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
+* **factories**: UseCartFactoryParam loadCart returns object with currentCart & currentCoupon, changed coupon to currentCoupon in signatures ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
 
 ### Changes
 

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (not released)
 
 ### Breaking changes
+* **factories**: UseCartFactoryParam loadCart returns object with currentCart & currentCoupon ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))
 
 ### Changes
 

--- a/packages/core/docs/shopify/changelog.md
+++ b/packages/core/docs/shopify/changelog.md
@@ -7,5 +7,4 @@
 
 ### Changes
 
-* **factories**: refactored setup using apiClientFactory (#4777)
 * **factories**: updated return signature of loadCart ([#4616](https://github.com/DivanteLtd/vue-storefront/issues/4616))

--- a/packages/shopify/composables/src/composables/useCart/loadCurrentCart.ts
+++ b/packages/shopify/composables/src/composables/useCart/loadCurrentCart.ts
@@ -12,7 +12,10 @@ const loadCurrentCart = async (cartParams: CartParams) => {
     Cookies.set('cart_id', cartResponse.id);
     Cookies.set('cart', cartResponse);
   }
-  return cartResponse;
+  return {
+    currentCart: cartResponse,
+    currentCoupon: null
+  };
 };
 
 export default loadCurrentCart;


### PR DESCRIPTION
I made `coupon` from `useCart` persistent. It has proper value in CT after refresh. It solves #4616 in 100%.

`coupon` looks like:
![image](https://user-images.githubusercontent.com/30155292/92605132-a3d50000-f2b1-11ea-9ad0-b8479ed7c78c.png)

I changed the call signature for applyCoupon & removeCoupon to make it work properly



┆Issue is synchronized with this [Jira Story](https://vsf.atlassian.net/browse/NEXT-270) by [Unito](https://www.unito.io/learn-more)
