### PR TITLE
Offline: order does not displayed in the users order history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 
+### Fixed
+- Offline order does not displayed in the user's order history (#5017)
+
 ## [1.12.2] - 2020.07.28
 
 ### Added

--- a/core/modules/order/index.ts
+++ b/core/modules/order/index.ts
@@ -75,6 +75,9 @@ export const OrderModule: StorefrontModule = function ({ store }) {
                       }
                     }
 
+                    if (orderData.transmited) {
+                      store.dispatch('user/refreshOrdersHistory', { resolvedFromCache: false })
+                    }
                     ordersCollection.setItem(orderId.toString(), orderData)
                   } else {
                     Logger.error(jsonResponse)()


### PR DESCRIPTION
### Related Issues
#5015 

closes #5015

### Short Description and Why It's Useful
After confirming the offline order the user needs to refresh once to get the latest order details that are placed offline.
The solution implemented is to call the refreshOrdersHistory to fetch the lastest order details and thus the user does not need to refresh the page.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

