### PR TITLE
WIP: Updated the code to display the shipping amount to the user in the offline mode in the price summary section (#5024)

### DIFF
--- a/core/modules/cart/helpers/calculateTotals.ts
+++ b/core/modules/cart/helpers/calculateTotals.ts
@@ -4,8 +4,18 @@ import ShippingMethod from '@vue-storefront/core/modules/cart/types/ShippingMeth
 import PaymentMethod from '@vue-storefront/core/modules/cart/types/PaymentMethod'
 import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
 
-const calculateTotals = (shippingMethod: ShippingMethod, paymentMethod: PaymentMethod, cartItems: CartItem[]) => {
-  const shippingTax = shippingMethod ? shippingMethod.price_incl_tax : 0
+const calculateTotals = (shippingMethods, shippingMethod: ShippingMethod, paymentMethod: PaymentMethod, cartItems: CartItem[]) => {
+  var shippingTax = 0
+  var shipping
+  if (shippingMethods) {
+    for (let i = 0; i < shippingMethods['length']; i++) {
+      if (shippingMethods[i].method_code === shippingMethod) {
+        shippingTax = shippingMethods[i].amount === 'Free' ? 0 : shippingMethods[i].amount
+        shipping = shippingMethods[i]
+        break
+      }
+    }
+  }
 
   const totalsArray = [
     {
@@ -27,11 +37,11 @@ const calculateTotals = (shippingMethod: ShippingMethod, paymentMethod: PaymentM
       value: paymentMethod.cost_incl_tax
     })
   }
-  if (shippingMethod) {
+  if (shipping) {
     totalsArray.push({
       code: 'shipping',
-      title: i18n.t(shippingMethod.method_title),
-      value: shippingMethod.price_incl_tax
+      title: i18n.t(shipping.method_title),
+      value: shippingTax
     })
   }
 

--- a/core/modules/cart/store/actions/methodsActions.ts
+++ b/core/modules/cart/store/actions/methodsActions.ts
@@ -17,7 +17,7 @@ const methodsActions = {
   },
   async setDefaultCheckoutMethods ({ getters, rootGetters, commit }) {
     if (!getters.getShippingMethodCode) {
-      commit(types.CART_UPD_SHIPPING, rootGetters['checkout/getDefaultShippingMethod'])
+      commit(types.CART_UPD_SHIPPING, rootGetters['checkout/getShippingMethods'])
     }
 
     if (!getters.getPaymentMethodCode) {

--- a/core/modules/cart/store/getters.ts
+++ b/core/modules/cart/store/getters.ts
@@ -26,7 +26,7 @@ const getters: GetterTree<CartState, RootState> = {
   getFirstShippingMethod: state => state.shipping instanceof Array ? state.shipping[0] : state.shipping,
   getFirstPaymentMethod: state => state.payment instanceof Array ? state.payment[0] : state.payment,
   getTotals: ({ cartItems, platformTotalSegments }, getters) =>
-    (platformTotalSegments && onlineHelper.isOnline) ? platformTotalSegments : calculateTotals(getters.getFirstShippingMethod, getters.getFirstPaymentMethod, cartItems),
+    (platformTotalSegments && onlineHelper.isOnline) ? platformTotalSegments : calculateTotals(getters.getShippingMethod, getters.getFirstShippingMethod.method_code, getters.getFirstPaymentMethod, cartItems),
   getItemsTotalQuantity: ({ cartItems }) => config.cart.minicartCountType === 'items' ? cartItems.length : sumBy(cartItems, p => p.qty),
   getCoupon: ({ platformTotals }): AppliedCoupon | false =>
     !(platformTotals && platformTotals.hasOwnProperty('coupon_code')) ? false : { code: platformTotals.coupon_code, discount: platformTotals.discount_amount },


### PR DESCRIPTION

### Related Issues
#5024

closes #

### Short Description and Why It's Useful
When we are offline, then on the checkout page the shipping amount is not displayed and the shipping amount is also not added up in the Totals.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

