### PR TITLE
Fixed the code to display the unique images and media_gallery on the product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 
+### Fixed
+- Fixed the code to display the unique images when setting the mergeConfigurableChildren to false (#5093)
+
 ## [1.12.2] - 2020.07.28
 
 ### Added

--- a/core/modules/catalog/helpers/getProductGallery.ts
+++ b/core/modules/catalog/helpers/getProductGallery.ts
@@ -10,7 +10,10 @@ import Product from '@vue-storefront/core/modules/catalog/types/Product';
 export default function getProductGallery (product: Product) {
   if (product.type_id === 'configurable' && product.hasOwnProperty('configurable_children')) {
     if (!config.products.gallery.mergeConfigurableChildren && product.is_configured) {
-      return uniqBy(attributeImages(product).concat(getMediaGallery(product)), 'src')
+      return uniqBy([
+        ...attributeImages(product),
+        ...getMediaGallery(product)
+      ], 'src')
     }
   }
 

--- a/core/modules/catalog/helpers/getProductGallery.ts
+++ b/core/modules/catalog/helpers/getProductGallery.ts
@@ -10,7 +10,7 @@ import Product from '@vue-storefront/core/modules/catalog/types/Product';
 export default function getProductGallery (product: Product) {
   if (product.type_id === 'configurable' && product.hasOwnProperty('configurable_children')) {
     if (!config.products.gallery.mergeConfigurableChildren && product.is_configured) {
-      return attributeImages(product)
+      return uniqBy(attributeImages(product).concat(getMediaGallery(product)), 'src')
     }
   }
 


### PR DESCRIPTION
### Related Issues
#5093 

closes #5093 

### Short Description and Why It's Useful
When changing the value of **mergeConfigurableChildren** to false the product gallery is not displayed as it should.
Using the uniqBy method to display only the unique images in the gallery and also added the media_gallery in the gallery to display all the images in the product gallery.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

### Screenshot:
When setting the mergeConfigurableChildren to false and not doing any other change:
![image](https://user-images.githubusercontent.com/41404838/97448260-7bcf5800-1956-11eb-874d-618d78356fe1.png)

When using the uniqBy and not adding the media_gallery:
![image](https://user-images.githubusercontent.com/41404838/97448779-044df880-1957-11eb-87b8-cd10c4a4c016.png)


When using the uniqBy method and adding the media_gallery:
![image](https://user-images.githubusercontent.com/41404838/97448359-986b9000-1956-11eb-8b5d-debddd86fc43.png)
