### PR TITLE
Use `queryString` library in `task/getUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve `getCategoryByParams` as it will return the first value of `state.categoriesMap` if no route-params are set - @cewald (#4926)
 - Bugfix for type error in `omitSelectedVariantFields` return value - @cewald (#4926)
+- Use `queryString` library in `task/getUrl` - @cewald (#5263)
 
 ### Changed / Improved
 

--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -95,7 +95,6 @@ function _internalExecute (resolve, reject, task: Task, currentToken, currentCar
   }
   const url = getUrl(task, currentToken, currentCartId)
   const payload = getPayload(task, currentToken)
-  console.error('url', task, url, currentToken, currentCartId)
   let silentMode = false
   Logger.info('Executing sync task ' + url, 'sync', task)()
   return fetch(url, payload).then((response) => {

--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -33,11 +33,11 @@ function _sleep (time) {
 function getUrl (task, currentToken, currentCartId) {
   const parsedUrl = queryString.parseUrl(task.url)
 
-  if (parsedUrl.query.token && parsedUrl.query.token === '{{token}}') {
+  if (parsedUrl?.query?.token === '{{token}}') {
     parsedUrl.query.token = (currentToken == null) ? '' : currentToken
   }
 
-  if (parsedUrl.query.cartId && parsedUrl.query.cartId === '{{cartId}}') {
+  if (parsedUrl?.query?.cartId === '{{cartId}}') {
     parsedUrl.query.cartId = (currentCartId == null) ? '' : currentCartId
   }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related #5043

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The new `adjustMultistoreApiUrl` method now uses url-encoding with `queryString.stringifyUrl()`. This leads into the problem that `getUrl()` method can't replace the tokens by simply using `replace`.

I refactored the `getUrl` method to use the `queryString` (`parseUrl`/`stringifyUrl`) library as it already is in us it for the `tokenInHeader` option.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

