### PR TITLE
Bugfix: Check if the variable backendPaymentMethods is iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lazy loading services - @Fifciu (#5208)
 - Removed redundant request header `Content-Type`, `mode`, `method` and `Accept` while  calling TaskQueue.execute/queue method, added these request headers in task getPayload method. (#5081)
 - Lazy loading async catalog helpers - @Fifciu (#5208)
-- Check if the variable backendPaymentMethods is iterable before the for...of loop - @rozzilla (#5289)
+- Check if the variable backendPaymentMethods is iterable before the for...of loop - @rozzilla [(#5289)](https://github.com/vuestorefront/vue-storefront/pull/5289)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lazy loading services - @Fifciu (#5208)
 - Removed redundant request header `Content-Type`, `mode`, `method` and `Accept` while  calling TaskQueue.execute/queue method, added these request headers in task getPayload method. (#5081)
 - Lazy loading async catalog helpers - @Fifciu (#5208)
-- Check if the variable backendPaymentMethods is iterable before the for...of loop - @rozzilla
+- Check if the variable backendPaymentMethods is iterable before the for...of loop - @rozzilla (#5289)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lazy loading services - @Fifciu (#5208)
 - Removed redundant request header `Content-Type`, `mode`, `method` and `Accept` while  calling TaskQueue.execute/queue method, added these request headers in task getPayload method. (#5081)
 - Lazy loading async catalog helpers - @Fifciu (#5208)
+- Check if the variable backendPaymentMethods is iterable before the for...of loop - @rozzilla
 
 ### Fixed
 

--- a/core/modules/cart/helpers/preparePaymentMethodsToSync.ts
+++ b/core/modules/cart/helpers/preparePaymentMethodsToSync.ts
@@ -11,7 +11,7 @@ const preparePaymentMethodsToSync = (
   const uniqueBackendMethods = []
 
   // Check if the variable is iterable before to enter in the for...of loop
-  if (typeof backendPaymentMethods[Symbol.iterator] === 'function') {
+  if (Array.isArray(backendPaymentMethods)) {
     for (const backendPaymentMethod of backendPaymentMethods) {
       if (isPaymentMethodNotExist(backendPaymentMethod, currentPaymentMethods)) {
         const backendMethod = {

--- a/core/modules/cart/helpers/preparePaymentMethodsToSync.ts
+++ b/core/modules/cart/helpers/preparePaymentMethodsToSync.ts
@@ -10,15 +10,18 @@ const preparePaymentMethodsToSync = (
   const paymentMethods = [...currentPaymentMethods]
   const uniqueBackendMethods = []
 
-  for (const backendPaymentMethod of backendPaymentMethods) {
-    if (isPaymentMethodNotExist(backendPaymentMethod, currentPaymentMethods)) {
-      const backendMethod = {
-        ...backendPaymentMethod,
-        is_server_method: true
-      }
+  // Check if the variable is iterable before to enter in the for...of loop
+  if (typeof backendPaymentMethods[Symbol.iterator] === 'function') {
+    for (const backendPaymentMethod of backendPaymentMethods) {
+      if (isPaymentMethodNotExist(backendPaymentMethod, currentPaymentMethods)) {
+        const backendMethod = {
+          ...backendPaymentMethod,
+          is_server_method: true
+        }
 
-      paymentMethods.push(backendMethod)
-      uniqueBackendMethods.push(backendMethod)
+        paymentMethods.push(backendMethod)
+        uniqueBackendMethods.push(backendMethod)
+      }
     }
   }
 


### PR DESCRIPTION
### Short Description and Why It's Useful
This is a bugfix for the "for...of" loop when the backendPaymentMethods is not iterable.
With this commit, before to enter in the loop, it checks if the variable is iterable.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

