### PR TITLE
5293-Remove-eventlistener-on-microcart-destroyed-hook:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Display default placeholder on the Product page (#5088)
+- Removed `visibilitychange` eventlistener on microcart beforeDestroy hook
 
 ## [1.12.2] - 2020.07.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Display default placeholder on the Product page (#5088)
-- Removed `visibilitychange` eventlistener on microcart beforeDestroy hook
+- Removed `visibilitychange` eventlistener on microcart beforeDestroy hook (#5293)
 
 ## [1.12.2] - 2020.07.28
 

--- a/core/modules/cart/components/MicrocartButton.ts
+++ b/core/modules/cart/components/MicrocartButton.ts
@@ -3,13 +3,17 @@
 export const MicrocartButton = {
   name: 'MicrocartButton',
   mounted () {
-    document.addEventListener('visibilitychange', () => {
-      if (!document.hidden) {
-        this.$store.dispatch('cart/load')
-      }
-    })
+    document.addEventListener('visibilitychange', this.loadCartIfTabVisible)
+  },
+  beforeDestroy () {
+    document.removeEventListener('visibilitychange', this.loadCartIfTabVisible)
   },
   methods: {
+    loadCartIfTabVisible () {
+      if (!document.hidden) {
+        this.$store.dispatch('cart/load');
+      }
+    },
     toggleMicrocart () {
       this.$store.dispatch('cart/toggleMicrocart')
     }


### PR DESCRIPTION
- refactored addeventlistener
- added method that load cart if tab is visible
- removed eventlistener
- updated changelog

### Related Issues
#5293

closes #

### Short Description and Why It's Useful
Not sere if it's useful.
On new version it was fixed by moving functionality to theme (https://github.com/DivanteLtd/vsf-default/blob/master/components/core/blocks/Header/MicrocartIcon.vue#L28)
But on 1.11 it's causing issues.
Also can be useful for themes, based on old default theme.



### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

