### PR TITLE
Update client state behaviour during checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lazy loading services - @Fifciu (#5208)
 - Removed redundant request header `Content-Type`, `mode`, `method` and `Accept` while  calling TaskQueue.execute/queue method, added these request headers in task getPayload method. (#5081)
 - Lazy loading async catalog helpers - @Fifciu (#5208)
+- New config `cart.forceUpdateStateClientInCheckout` to change default behavior in checkout - @janmarkuslanger (#5345)
 
 ### Fixed
 

--- a/config/default.json
+++ b/config/default.json
@@ -496,6 +496,7 @@
       "width": 150,
       "height": 150
     },
+    "forceUpdateStateClientInCheckout": true,
     "serverMergeByDefault": true,
     "serverSyncCanRemoveLocalItems": false,
     "serverSyncCanModifyLocalItems": false,

--- a/core/modules/cart/store/actions/synchronizeActions.ts
+++ b/core/modules/cart/store/actions/synchronizeActions.ts
@@ -48,7 +48,7 @@ const synchronizeActions = {
     return dispatch('sync', { forceClientState, dryRun })
   },
   async sync ({ getters, rootGetters, commit, dispatch, state }, { forceClientState = false, dryRun = false, mergeQty = false, forceSync = false }) {
-    const shouldUpdateClientState = rootGetters['checkout/isUserInCheckout'] || forceClientState
+    const shouldUpdateClientState = (config.cart.forceUpdateStateClientInCheckout !== false && rootGetters['checkout/isUserInCheckout']) || forceClientState
     const { getCartItems, canUpdateMethods, isSyncRequired, bypassCounter } = getters
     if ((!canUpdateMethods || !isSyncRequired) && !forceSync) return createDiffLog()
     commit(types.CART_SET_SYNC)


### PR DESCRIPTION
### Related Issues
#5345

closes #

### Short Description and Why It's Useful
You can now control if you want to replace your cart if you login during checkout.

If `forceUpdateStateClientInCheckout` is true or not defined it behaves like before and nothing will change. 
You need to set `forceUpdateStateClientInCheckout` to `false` then your items will be merged with the items you have stored in your account. 


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

