### PR TITLE
Add optional config for shared user config (#5314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lazy loading services - @Fifciu (#5208)
 - Removed redundant request header `Content-Type`, `mode`, `method` and `Accept` while  calling TaskQueue.execute/queue method, added these request headers in task getPayload method. (#5081)
 - Lazy loading async catalog helpers - @Fifciu (#5208)
+- New config option `storeViews.commonUserCache` to optionally handle the shared storage of users differently than other cache. - @rain2o (#5314)
 
 ### Fixed
 

--- a/config/default.json
+++ b/config/default.json
@@ -185,7 +185,8 @@
   "defaultStoreCode": "",
   "storeViews": {
     "multistore": false,
-    "commonCache": false
+    "commonCache": false,
+    "commonUserCache": false
   },
   "entities": {
     "optimize": true,

--- a/core/modules/user/index.ts
+++ b/core/modules/user/index.ts
@@ -5,9 +5,10 @@ import { isServer } from '@vue-storefront/core/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import * as types from './store/mutation-types'
+import config from 'config'
 
 export const UserModule: StorefrontModule = async function ({ store }) {
-  StorageManager.init('user')
+  StorageManager.init('user', !config.storeViews.commonUserCache)
   store.registerModule('user', userStore)
   if (!isServer) {
     EventBus.$on('user-before-logout', () => {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5314 

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Adds the ability to manage the configuration of User data being cached separately per store (in multistore setup) or not. As described in issue #5314 there can be a situation (with Magento 1 & 2 at least) where you can have separate catalog data per store, but users are shared across all stores.


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

