### PR TITLE
Updated: the store to maintain state for the filter aggregations

### DIFF
--- a/core/modules/catalog-next/store/category/CategoryState.ts
+++ b/core/modules/catalog-next/store/category/CategoryState.ts
@@ -7,5 +7,6 @@ export default interface CategoryState {
   filtersMap: { [id: string]: any },
   products: Product[],
   searchProductsStats: any,
-  menuCategories: Category[]
+  menuCategories: Category[],
+  aggregations: { [id: string]: any }
 }

--- a/core/modules/catalog-next/store/category/actions.ts
+++ b/core/modules/catalog-next/store/category/actions.ts
@@ -184,7 +184,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     if (categoryMappedFilters && filtersKeys.length) {
       resultFilters = Object.assign(cloneDeep(categoryMappedFilters), cloneDeep(omit(aggregationFilters, filtersKeys)))
     }
-    commit(types.CATEGORY_SET_CATEGORY_FILTERS, { category, filters: resultFilters })
+    commit(types.CATEGORY_SET_CATEGORY_FILTERS, { category, filters: resultFilters, aggregations })
   },
 
   async switchSearchFilters ({ dispatch }, filterVariants: FilterVariant[] = []) {

--- a/core/modules/catalog-next/store/category/getters.ts
+++ b/core/modules/catalog-next/store/category/getters.ts
@@ -143,6 +143,10 @@ const getters: GetterTree<CategoryState, RootState> = {
   },
   getMenuCategories (state, getters, rootState, rootGetters) {
     return state.menuCategories || rootGetters['category/getCategories']
+  },
+  getAggregations: (state, getters) => {
+    const categoryId = get(getters.getCurrentCategory, 'id', null)
+    return state.aggregations[categoryId] || {}
   }
 }
 

--- a/core/modules/catalog-next/store/category/index.ts
+++ b/core/modules/catalog-next/store/category/index.ts
@@ -13,7 +13,8 @@ export const categoryModule: Module<CategoryState, RootState> = {
     filtersMap: {},
     products: [],
     searchProductsStats: {},
-    menuCategories: []
+    menuCategories: [],
+    aggregations: {}
   },
   getters,
   actions,

--- a/core/modules/catalog-next/store/category/mutations.ts
+++ b/core/modules/catalog-next/store/category/mutations.ts
@@ -34,8 +34,9 @@ const mutations: MutationTree<CategoryState> = {
   [types.CATEGORY_ADD_NOT_FOUND_CATEGORY_IDS] (state, categoryIds: string[] = []) {
     state.notFoundCategoryIds = [...state.notFoundCategoryIds, ...categoryIds]
   },
-  [types.CATEGORY_SET_CATEGORY_FILTERS] (state, { category, filters }) {
+  [types.CATEGORY_SET_CATEGORY_FILTERS] (state, { category, filters, aggregations }) {
     Vue.set(state.filtersMap, category.id, filters)
+    Vue.set(state.aggregations, category.id, aggregations)
   },
   [types.CATEGORY_SET_SEARCH_PRODUCTS_STATS] (state, stats = {}) {
     state.searchProductsStats = stats


### PR DESCRIPTION
### Related Issues
https://github.com/vuestorefront/vsf-capybara/issues/554

closes #

### Short Description and Why It's Useful
Maintaining a separate state for the aggregations will help not subscribing the action at component load time and also will solve the issue of filter count issue.


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

