### PR TITLE
Fix nuxt-theme deps and Boilerplate types

### DIFF
--- a/packages/boilerplate/api-client/src/types.ts
+++ b/packages/boilerplate/api-client/src/types.ts
@@ -1,5 +1,5 @@
-export type Cart = {}
-export type Wishlist = {}
+export type Cart = Record<string, unknown>;
+export type Wishlist = Record<string, unknown>;
 export type ProductVariant = {
   _id: number;
   _description: string;
@@ -11,13 +11,13 @@ export type ProductVariant = {
     original: number;
     current: number;
   };
-}
+};
 export type Category = {
   id: number;
   name: string;
   slug: string;
   items: Category[];
-}
-export type CategoryFilter = {}
-export type ShippingMethod = {}
-export type LineItem = {};
+};
+export type CategoryFilter = Record<string, unknown>;
+export type ShippingMethod = Record<string, unknown>;
+export type LineItem = Record<string, unknown>;

--- a/packages/boilerplate/composables/package.json
+++ b/packages/boilerplate/composables/package.json
@@ -16,6 +16,9 @@
     "@vue-storefront/boilerplate-api": "0.0.1",
     "@vue-storefront/core": "^2.2.0"
   },
+  "peerDependencies": {
+    "@vue/composition-api": "1.0.0-beta.21"
+  },
   "files": [
     "lib/**/*"
   ],

--- a/packages/boilerplate/composables/src/types/index.ts
+++ b/packages/boilerplate/composables/src/types/index.ts
@@ -1,18 +1,6 @@
 export { UseCategory, UseProduct } from '@vue-storefront/core';
 
-export type ProductsResponse = {
-  data: Product[];
-  total: number;
-};
-
-export type OrdersResponse = {
-  data: any[];
-  total: number;
-};
-
-export type OrderSearchParams = Record<string, any>;
-
-export type Category = {};
+export type Category = Record<string, unknown>;
 
 export type User = {
   firstName?: string;
@@ -20,24 +8,36 @@ export type User = {
   email?: string;
 };
 
-export type UserAddress = {};
+export type UserAddress = Record<string, unknown>;
 
-export type Cart = {};
+export type Cart = Record<string, unknown>;
 
-export type CartItem = {};
+export type CartItem = Record<string, unknown>;
 
-export type Coupon = {};
+export type Coupon = Record<string, unknown>;
 
-export type Order = {};
+export type Order = Record<string, unknown>;
 
-export type OrderItem = {};
+export type OrderItem = Record<string, unknown>;
 
-export type Product = {};
+export type Product = Record<string, unknown>;
 
-export type Review = {};
+export type Review = Record<string, unknown>;
 
-export type ShippingMethod = {};
+export type ShippingMethod = Record<string, unknown>;
 
-export type WishlistProduct = {};
+export type WishlistProduct = Record<string, unknown>;
 
-export type Wishlist = {};
+export type Wishlist = Record<string, unknown>;
+
+export type ProductsResponse = {
+  data: Product[];
+  total: number;
+};
+
+export type OrderSearchParams = Record<string, any>;
+
+export type OrdersResponse = {
+  data: any[];
+  total: number;
+};

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.2.1
+- fixed `vue-lazy-hydration` dependency in `nuxt-theme-module` and improved typings in Boilerplate ([#5403](https://github.com/DivanteLtd/vue-storefront/issues/5403))
+
 ## 2.2.0
 - added bottom margin to fix visibility of last footer category ([#5253](https://github.com/DivanteLtd/vue-storefront/issues/5253))
 - [BREAKING] refactored names of many factory methods and composable methods, details in linked PR ([#5299](https://github.com/DivanteLtd/vue-storefront/pull/5299))

--- a/packages/core/nuxt-theme-module/package.json
+++ b/packages/core/nuxt-theme-module/package.json
@@ -16,13 +16,13 @@
     "ejs": "^3.0.2",
     "loglevel": "^1.6.7",
     "ts-loader": "^8.0.3",
-    "vue": "^2.6.11",
-    "vue-lazy-hydration": "^2.0.0-beta.4"
+    "vue": "^2.6.11"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "vue-lazy-hydration": "^2.0.0-beta.4"
   }
 }

--- a/packages/rollup.base.config.js
+++ b/packages/rollup.base.config.js
@@ -16,7 +16,8 @@ export function generateBaseConfig(pkg) {
       }
     ],
     external: [
-      ...Object.keys(pkg.dependencies || {})
+      ...Object.keys(pkg.dependencies || {}),
+      ...Object.keys(pkg.peerDependencies || {})
     ],
     plugins: [
       typescript({


### PR DESCRIPTION
### Short Description and Why It's Useful
Move `vue-lazy-hydration` dependency in `nuxt-theme-module` from `devDependencies` to `dependencies` and update types in Boilerplate to make eslint happy.

### Which Environment This Relates To
- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [ ] No upgrade steps required (100% backward compatibility and no breaking changes)
- [X] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature
