### PR TITLE
Missing spread operator leading to failing order queue

### DIFF
--- a/core/modules/order/store/actions.ts
+++ b/core/modules/order/store/actions.ts
@@ -77,7 +77,7 @@ const actions: ActionTree<OrderState, RootState> = {
     throw new Error('Unhandled place order request error')
   },
   handlePlacingOrderFailed ({ commit, dispatch }, { newOrder, currentOrderHash }) {
-    const order = { newOrder, transmited: false }
+    const order = { ...newOrder, transmited: false }
     commit(types.ORDER_REMOVE_SESSION_ORDER_HASH, currentOrderHash)
     dispatch('notification/spawnNotification', notifications.orderCannotTransfered(), { root: true })
     dispatch('enqueueOrder', { newOrder: order })

--- a/core/modules/order/test/unit/store/actions.spec.ts
+++ b/core/modules/order/test/unit/store/actions.spec.ts
@@ -1222,7 +1222,7 @@ describe('Order actions', () => {
           payment_method_additional: 'four'
         }
       }
-      const expectedOrder = { newOrder, transmited: false }
+      const expectedOrder = { ...newOrder, transmited: false }
 
       const wrapper = (orderActions: any) => orderActions.handlePlacingOrderFailed(contextMock, { newOrder, currentOrderHash });
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4634

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Adds a missing spread operator to prevent an invalid order object to be added to the order queue.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature
- [ ] (Next only) I've followed this [instruction](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and I've created a `.js` file with information about my Pull Request

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

