### PR TITLE
Add correct generic type to `catalog-next/productPageVisitedHook`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changing email & password at once - @Fifciu ([#5315](https://github.com/vuestorefront/vue-storefront/issues/5315))
 - Improved: the code to remove the page key from the query before applying a filter - @ymaheshwari1 ([VSF Capybara #561](https://github.com/vuestorefront/vsf-capybara/issues/561))
 - Changing regex responsible for UnicodeAlpha validation and added unit tests - @lukaszjedrasik ([#5340](https://github.com/vuestorefront/vue-storefront/issues/5340))
+- Add correct generic type to `catalog-next/productPageVisitedHook` - @cewald (#5652)
+
 ### Changed / Improved
 
 - Add return types for `beforeOutputRendered` response mutator hook in `hooks.ts` - @lsliwaradioluz (#5242)

--- a/core/modules/catalog-next/hooks.ts
+++ b/core/modules/catalog-next/hooks.ts
@@ -1,5 +1,6 @@
-import { createListenerHook, createMutatorHook } from '@vue-storefront/core/lib/hooks'
-import { Category } from './types/Category';
+import { createListenerHook } from '@vue-storefront/core/lib/hooks'
+import { Category } from './types/Category'
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
 
 const {
   hook: categoryPageVisitedHook,
@@ -9,7 +10,7 @@ const {
 const {
   hook: productPageVisitedHook,
   executor: productPageVisitedExecutor
-} = createListenerHook<Category>()
+} = createListenerHook<Product>()
 
 /** Only for internal usage */
 const catalogHooksExecutors = {


### PR DESCRIPTION
### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The wrong generic typescript type is passed to the `productPageVisitedHook` event-hook. This could lead into typescript exceptions during build/linting.

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [x] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


