### PR TITLE
#5613 - fix correct register flow

### DIFF
--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
@@ -25,7 +25,7 @@ export const handleAfterAuth = async ({ sdkAuth, tokenProvider, apolloReq, curre
     const { email, password } = apolloReq.variables.draft;
     Logger.debug('Apollo authLinkAfter, customerPasswordFlow', apolloReq.operationName);
 
-    if (!response.errors.length) {
+    if (!response.errors?.length) {
       const token = await sdkAuth.customerPasswordFlow({ username: email, password });
       tokenProvider.setTokenInfo(token);
       Logger.debug('Apollo authLinkAfter, customerPasswordFlow, generated token: ', getAccessToken(token));


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5613 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Correction to the previously merged functionality. Response for a wrong user register contains two fields (data and errors) while for a correct register it contains only data property. Because of that, the previously developed solution fixed error for register already registered user, but made it impossible to register completely new account. 


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


