### PR TITLE
Restore and update useFacet docs

### DIFF
--- a/packages/core/docs/commercetools/composables/use-facet.md
+++ b/packages/core/docs/commercetools/composables/use-facet.md
@@ -170,7 +170,7 @@ type ProductVariant = {
 ## Configuration
 
 ::: warning
-Configuration can be changed only for th Enterprise version of this package.
+Configuration can be changed only for the Enterprise version of this package.
 :::
 
 Faceting configuration can be modified to change available sorting options, filters, etc.
@@ -179,15 +179,11 @@ If the explicit configuration is not provided, the following defaults will be us
 
 ```javascript
 {
-  pageOptions: [
-    20,
-    50,
-    100
-  ],
+  pageOptions: [20, 50, 100],
   subcategoriesLimit: 100,
   availableFacets: [
-    { facet: 'categories.id', type: 'string', option: 'subtree("*")', name: 'category' },
-    { facet: 'variants.attributes.size', type: 'number', option: '', name: 'size' },
+    { facet: 'categories.id', type: 'string', option: 'subtree("*")', name: 'category', filteringStrategy: 'query' },  // Don't change the "name" of this facet
+    { facet: 'variants.attributes.size', type: 'string', option: '', name: 'size' },
     { facet: 'variants.attributes.color.key', type: 'string', option: '', name: 'color' }
   ],
   sortingOptions: [
@@ -200,9 +196,47 @@ If the explicit configuration is not provided, the following defaults will be us
 }
 ```
 
-Configuration can be modified by passing identical configuration to:
+- `pageOptions` - an array of number of elements displayed per page.
+- `subcategoriesLimit` - the maximum number of subcategories displayed for any given category.
+- `availableFacets` - an array of filters available to the user.
+  - `facet` - facet expressions described on [this page](https://docs.commercetools.com/api/projects/products-search#termfacetexpression).
+  - `type` - `facet` data type. Valid values are `string`, `date`, `time`, `datetime`, `boolean` or `number`.
+  - `option` - filtering options described on [this page](https://docs.commercetools.com/api/projects/products-search#filters).
+  - `name` - facet alias described on [this page](https://docs.commercetools.com/api/projects/products-search#alias). `category` alias for the first facet shown above is a constant and shouldn't be changed.
+  - `filteringStrategy` - scope applied to this specific filter. Possible values are `filter`, `query` or `facets`. For more information refer to [this page](https://docs.commercetools.com/api/projects/products-search#filters). 
+- `sortingOptions` - an array of sorting options available to the user.
+  - `id` - unique `identifier` for the option.
+  - `name` - label for the option.
+  - `facet` - the name of the field to sort by. For more information refer to [this page](https://docs.commercetools.com/api/projects/products-search#sorting).
+  - `direction` - sorting direction. Valid values are `asc` or `desc`.
+- `filteringStrategy` - fallback scope applied to the facets that don't have strategy defined. Possible values are `filter`, `query` or `facets`. For more information refer to [this page](https://docs.commercetools.com/api/projects/products-search#filters).
+
+If the default configuration is modified, two identical copies must be passed to:
 - `@vsf-enterprise/ct-faceting/nuxt` module in `nuxt.config.js`.
 - `@vsf-enterprise/ct-faceting/server` integration in `middleware.config.js`.
+
+```javascript
+// nuxt.config.js
+export default {
+  buildModules: [
+    ['@vsf-enterprise/ct-faceting/nuxt', {
+      // options
+    }],
+  ]
+};
+
+// middleware.config.js
+module.exports = {
+  integrations: {
+    ctf: {
+      location: '@vsf-enterprise/ct-faceting/server',
+      configuration: {
+        // options
+      }
+    }
+  }
+};
+```
 
 ## Example
 

--- a/packages/core/docs/commercetools/composables/use-facet.md
+++ b/packages/core/docs/commercetools/composables/use-facet.md
@@ -169,22 +169,24 @@ type ProductVariant = {
 
 ## Configuration
 
-::: warning
+::: tip
 Configuration can be changed only for the Enterprise version of this package.
 :::
 
-Faceting configuration can be modified to change available sorting options, filters, etc.
-
-Two identical options must be passed to:
+Faceting configuration can be modified to change available sorting options, filters, etc. It must be passed to:
 - `@vsf-enterprise/ct-faceting/nuxt` module in `nuxt.config.js`.
 - `@vsf-enterprise/ct-faceting/server` integration in `middleware.config.js`.
+
+::: warning Keep your configuration synchronized
+Parts of the configuration marked as `<FACETING_OPTIONS>` must be identical in both files.
+:::
 
 ```javascript
 // nuxt.config.js
 export default {
   buildModules: [
     ['@vsf-enterprise/ct-faceting/nuxt', {
-      // options
+      // <FACETING_OPTIONS>
     }],
   ]
 };
@@ -195,14 +197,26 @@ module.exports = {
     ctf: {
       location: '@vsf-enterprise/ct-faceting/server',
       configuration: {
-        // options
+        api: {
+          authHost: "<CT_AUTH_HOST>",
+          projectKey: "<CT_PROJECT_KEY>",
+          clientId: "<CT_CLIENT_ID>",
+          clientSecret: "<CT_CLIENT_SECRET>",
+          scopes: [
+            "<CT_AUTH_SCOPE>"
+          ],
+        },
+        faceting: {
+          host: "<CT_HOST>"
+        },
+        // <FACETING_OPTIONS>
       }
     }
   }
 };
 ```
 
-If the explicit configuration is not provided, the following defaults will be used:
+If the explicit configuration is not provided in place of `<FACETING_OPTIONS>`, the following defaults will be used:
 
 ```javascript
 {

--- a/packages/core/docs/commercetools/composables/use-facet.md
+++ b/packages/core/docs/commercetools/composables/use-facet.md
@@ -175,6 +175,33 @@ Configuration can be changed only for the Enterprise version of this package.
 
 Faceting configuration can be modified to change available sorting options, filters, etc.
 
+Two identical options must be passed to:
+- `@vsf-enterprise/ct-faceting/nuxt` module in `nuxt.config.js`.
+- `@vsf-enterprise/ct-faceting/server` integration in `middleware.config.js`.
+
+```javascript
+// nuxt.config.js
+export default {
+  buildModules: [
+    ['@vsf-enterprise/ct-faceting/nuxt', {
+      // options
+    }],
+  ]
+};
+
+// middleware.config.js
+module.exports = {
+  integrations: {
+    ctf: {
+      location: '@vsf-enterprise/ct-faceting/server',
+      configuration: {
+        // options
+      }
+    }
+  }
+};
+```
+
 If the explicit configuration is not provided, the following defaults will be used:
 
 ```javascript
@@ -210,33 +237,6 @@ If the explicit configuration is not provided, the following defaults will be us
   - `facet` - the name of the field to sort by. For more information refer to [this page](https://docs.commercetools.com/api/projects/products-search#sorting).
   - `direction` - sorting direction. Valid values are `asc` or `desc`.
 - `filteringStrategy` - fallback scope applied to the facets that don't have strategy defined. Possible values are `filter`, `query` or `facets`. For more information refer to [this page](https://docs.commercetools.com/api/projects/products-search#filters).
-
-If the default configuration is modified, two identical copies must be passed to:
-- `@vsf-enterprise/ct-faceting/nuxt` module in `nuxt.config.js`.
-- `@vsf-enterprise/ct-faceting/server` integration in `middleware.config.js`.
-
-```javascript
-// nuxt.config.js
-export default {
-  buildModules: [
-    ['@vsf-enterprise/ct-faceting/nuxt', {
-      // options
-    }],
-  ]
-};
-
-// middleware.config.js
-module.exports = {
-  integrations: {
-    ctf: {
-      location: '@vsf-enterprise/ct-faceting/server',
-      configuration: {
-        // options
-      }
-    }
-  }
-};
-```
 
 ## Example
 


### PR DESCRIPTION
This PR restores and updates `useFacet` docs that were added 3 weeks ago, but disappeared from the docs https://github.com/vuestorefront/vue-storefront/pull/5600/files