### PR TITLE
Multi-tab cart-sync in multi-store environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changing email & password at once - @Fifciu ([#5315](https://github.com/vuestorefront/vue-storefront/issues/5315))
 - Improved: the code to remove the page key from the query before applying a filter - @ymaheshwari1 ([VSF Capybara #561](https://github.com/vuestorefront/vsf-capybara/issues/561))
 - Changing regex responsible for UnicodeAlpha validation and added unit tests - @lukaszjedrasik ([#5340](https://github.com/vuestorefront/vue-storefront/issues/5340))
+- Multi-tab cart-sync in multi-store environment - @cewald (#5711)
+
 ### Changed / Improved
 
 - Add return types for `beforeOutputRendered` response mutator hook in `hooks.ts` - @lsliwaradioluz (#5242)

--- a/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
+++ b/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
@@ -1,7 +1,16 @@
-import rootStore from '@vue-storefront/core/store';
+import rootStore from '@vue-storefront/core/store'
+import { storeViews } from 'config'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 function getItemsFromStorage ({ key }) {
-  if (key.endsWith('shop/cart/current-cart')) {
+  if (
+    key === 'shop/cart/current-cart' ||
+    (
+      storeViews.multistore &&
+      !storeViews.commonCache &&
+      key === `${currentStoreView().storeCode}-shop/cart/current-cart`
+    )
+  ) {
     const storedItems = JSON.parse(localStorage[key])
     rootStore.dispatch('cart/syncCartWhenLocalStorageChange', { items: storedItems })
   }

--- a/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
+++ b/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
@@ -1,7 +1,7 @@
 import rootStore from '@vue-storefront/core/store';
 
 function getItemsFromStorage ({ key }) {
-  if (key === 'shop/cart/current-cart') {
+  if (key.endsWith('shop/cart/current-cart')) {
     const storedItems = JSON.parse(localStorage[key])
     rootStore.dispatch('cart/syncCartWhenLocalStorageChange', { items: storedItems })
   }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related to #3838 & #4083

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The multi-tab cart-sync feature wouldn't work in a multistore-environment with disabled `storeViews.commonCache` feature as the keys in local-storage are prefixed with the store-code like `de-shop/cart/current-cart`.

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [x] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


