### PR TITLE
Bugfix for cart-tab-sync in multistore environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - servercart-after-diff event payload - Fifciu (#5365)
 - Fix Original Price Calculation typo - @akucharczyk / @lukaszjedrasik (#5472)
 - Purge loader works properly with dynamic config reload - @Fifciu
+- Multi-tab cart-sync in multi-store environment - @cewald (#5711, #5732)
+
 ### Changed / Improved
 
 - Moved hardcoded fields from omitSelectedVariantFields.ts to config (#4679)

--- a/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
+++ b/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
@@ -1,12 +1,20 @@
-import rootStore from '@vue-storefront/core/store';
+import rootStore from '@vue-storefront/core/store'
+import { storeViews } from 'config'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 function getItemsFromStorage ({ key }) {
   const value = JSON.parse(localStorage[key])
-  if (key === 'shop/cart/current-cart') {
+  if (checkMultistoreKey(key, 'shop/cart/current-cart')) {
     rootStore.dispatch('cart/updateCart', { items: value })
-  } else if (key === 'shop/cart/current-totals') {
+  } else if (checkMultistoreKey(key, 'shop/cart/current-totals')) {
     rootStore.dispatch('cart/updateTotals', value)
   }
+}
+
+function checkMultistoreKey (key: string, path: string): boolean {
+  const { multistore, commonCache } = storeViews
+  if (!multistore || (multistore && commonCache)) return key === path
+  return key === `${currentStoreView().storeCode}-${path}`
 }
 
 function addEventListener () {

--- a/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
+++ b/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
@@ -9,10 +9,11 @@ function checkMultistoreKey (key: string, path: string): boolean {
 }
 
 function getItemsFromStorage ({ key }) {
-  const value = JSON.parse(localStorage[key])
   if (checkMultistoreKey(key, 'shop/cart/current-cart')) {
+    const value = JSON.parse(localStorage[key])
     rootStore.dispatch('cart/updateCart', { items: value })
   } else if (checkMultistoreKey(key, 'shop/cart/current-totals')) {
+    const value = JSON.parse(localStorage[key])
     rootStore.dispatch('cart/updateTotals', value)
   }
 }

--- a/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
+++ b/core/modules/cart/helpers/syncCartWhenLocalStorageChange.ts
@@ -2,6 +2,12 @@ import rootStore from '@vue-storefront/core/store'
 import { storeViews } from 'config'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
+function checkMultistoreKey (key: string, path: string): boolean {
+  const { multistore, commonCache } = storeViews
+  if (!multistore || (multistore && commonCache)) return key === path
+  return key === `${currentStoreView().storeCode}-${path}`
+}
+
 function getItemsFromStorage ({ key }) {
   const value = JSON.parse(localStorage[key])
   if (checkMultistoreKey(key, 'shop/cart/current-cart')) {
@@ -9,12 +15,6 @@ function getItemsFromStorage ({ key }) {
   } else if (checkMultistoreKey(key, 'shop/cart/current-totals')) {
     rootStore.dispatch('cart/updateTotals', value)
   }
-}
-
-function checkMultistoreKey (key: string, path: string): boolean {
-  const { multistore, commonCache } = storeViews
-  if (!multistore || (multistore && commonCache)) return key === path
-  return key === `${currentStoreView().storeCode}-${path}`
 }
 
 function addEventListener () {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related to #3838 & #4083

This is a copy of #5711 rebased on `hotfix/v1.12.3` branch.
 
### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The multi-tab cart-sync feature wouldn't work in a multistore-environment with disabled `storeViews.commonCache` feature as the keys in local-storage are prefixed with the store-code like `de-shop/cart/current-cart`.

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [x] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


