### PR TITLE
NEXT: fix sorting on category page in CT

### DIFF
--- a/packages/commercetools/api-client/src/api/getProduct/index.ts
+++ b/packages/commercetools/api-client/src/api/getProduct/index.ts
@@ -15,6 +15,7 @@ const getProduct = async (context, params, customQuery?: CustomQuery) => {
     where: buildProductWhere(context.config, params),
     skus: params.skus,
     limit: params.limit,
+    sort: params.sort,
     offset: params.offset,
     locale,
     acceptLanguage,

--- a/packages/commercetools/composables/src/getters/facetGetters.ts
+++ b/packages/commercetools/composables/src/getters/facetGetters.ts
@@ -20,12 +20,11 @@ const getGrouped = (searchData: SearchData, criteria?: string[]): AgnosticGroupe
 
 const getSortOptions = (searchData: SearchData): AgnosticSort => {
   const options = [
-    { type: 'sort', id: 'latest', value: 'Latest', count: null },
-    { type: 'sort', id: 'price-up', value: 'Price from low to high', count: null },
-    { type: 'sort', id: 'price-down', value: 'Price from high to low', count: null }
+    { type: 'sort', id: 'masterData.current.name.en asc', value: 'Name from A to Z', count: null },
+    { type: 'sort', id: 'masterData.current.name.en desc', value: 'Name from Z to A', count: null }
   ].map(o => ({ ...o, selected: o.id === searchData.input.sort }));
 
-  const selected = options.find(o => o.id === searchData.input.sort)?.id || 'latest';
+  const selected = options.find(o => o.id === searchData.input.sort)?.id || 'masterData.current.name.en asc';
 
   return { options, selected };
 };

--- a/packages/commercetools/composables/src/useFacet/index.ts
+++ b/packages/commercetools/composables/src/useFacet/index.ts
@@ -18,14 +18,15 @@ const factoryParams = {
       ...prev,
       ...inputFilters[curr].map(value => ({ type: AttributeType.STRING, name: curr, value }))
     ]), []);
+    const inputSort = params.input.sort;
 
     const productResponse = await context.$ct.api.getProduct({
       catId: categories[0].id,
       limit: itemsPerPage,
       offset: (params.input.page - 1) * itemsPerPage,
-      filters
+      filters,
       // TODO: https://github.com/DivanteLtd/vue-storefront/issues/4857
-      // sort: params.sort
+      sort: [inputSort]
     });
     const enhancedProductResponse = enhanceProduct(productResponse, context);
     const products = (enhancedProductResponse.data as any)._variants as ProductVariant[];

--- a/packages/commercetools/theme/composables/useUiHelpers/index.ts
+++ b/packages/commercetools/theme/composables/useUiHelpers/index.ts
@@ -32,12 +32,11 @@ const useUiHelpers = () => {
   const getFacetsFromURL = () => {
     const { query, params } = instance.$router.history.current;
     const categorySlug = Object.keys(params).reduce((prev, curr) => params[curr] || prev, params.slug_1);
-
     return {
       rootCatSlug: params.slug_1,
       categorySlug,
       page: parseInt(query.page, 10) || 1,
-      sort: query.sort || 'latest',
+      sort: query.sort || 'masterData.current.name.en asc',
       filters: getFiltersDataFromUrl(instance, true),
       itemsPerPage: parseInt(query.itemsPerPage, 10) || 20,
       term: query.term
@@ -53,7 +52,7 @@ const useUiHelpers = () => {
       rootCatSlug: params.slug_1,
       categorySlug,
       page: parseInt(query.page, 10) || 1,
-      sort: query.sort || 'latest',
+      sort: query.sort || 'masterData.current.name.en asc',
       filters: getFiltersDataFromUrl(instance, true),
       itemsPerPage: parseInt(query.itemsPerPage, 10) || 20,
       term: query.term

--- a/packages/core/docs/changelog/5697.js
+++ b/packages/core/docs/changelog/5697.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fix sorting by product name on category page',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/5697',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Adam Pawliński',
+  linkToGitHubAccount: 'https://github.com/AdamPawlinski'
+};


### PR DESCRIPTION
### Related Issues
closes #5697  

### Short Description of the PR
Fix sorting on category page, but instead of sorting by price (which is impossible according to commercetools docs) there is sorting by name implemented. 


### Screenshots of Visual Changes before/after (if There Are Any)
![image](https://user-images.githubusercontent.com/32042425/113838987-945a5e80-978f-11eb-87d7-f8a7081a3066.png)


### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


