### PR TITLE
fix: hydration error on category page in desktop mode

### DIFF
--- a/packages/core/docs/changelog/5744.js
+++ b/packages/core/docs/changelog/5744.js
@@ -2,14 +2,7 @@ module.exports = {
   description: 'Fix hydration bug on category page',
   link: 'https://github.com/vuestorefront/vue-storefront/issues/5744',
   isBreaking: false,
-  breakingChanges: [
-    {
-      module: 'affected module',
-      before: 'how it was',
-      after: 'how it is',
-      comment: 'quick migration guide'
-    }
-  ],
+  breakingChanges: [],
   author: 'Adam Pawliński',
   linkToGitHubAccount: 'https://github.com/AdamPawlinski'
 };

--- a/packages/core/docs/changelog/5744.js
+++ b/packages/core/docs/changelog/5744.js
@@ -1,0 +1,15 @@
+module.exports = {
+  description: 'Fix hydration bug on category page',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/5744',
+  isBreaking: false,
+  breakingChanges: [
+    {
+      module: 'affected module',
+      before: 'how it was',
+      after: 'how it is',
+      comment: 'quick migration guide'
+    }
+  ],
+  author: 'Adam Pawliński',
+  linkToGitHubAccount: 'https://github.com/AdamPawlinski'
+};

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -12,30 +12,8 @@
         </nuxt-link>
       </template>
       <template #navigation>
-        <SfHeaderNavigationItem class="nav-item" data-cy="app-header-url_women" label="WOMEN" :link="localePath('/c/women')">
-          <!-- <template name="desktop-navigation-item">
-            <SfLink class="sf-header-navigation-item__link" :link="link">{{
-              label
-            }}</SfLink>
-          </template> -->
-
-          <template #mobile-navigation-item>
-            <SfMenuItem label="WOMEN" class="sf-header-navigation-item__menu-item">
-              <template #mobile-nav-icon>
-                &#8203;
-              </template>
-            </SfMenuItem>
-          </template>
-        </SfHeaderNavigationItem>
-        <SfHeaderNavigationItem class="nav-item"  data-cy="app-header-url_men" label="MEN" :link="localePath('/c/men')" >
-          <template #mobile-navigation-item>
-            <SfMenuItem label="MEN" class="sf-header-navigation-item__menu-item">
-              <template #mobile-nav-icon>
-                &#8203;
-              </template>
-            </SfMenuItem>
-          </template>
-        </SfHeaderNavigationItem>
+        <SfHeaderNavigationItem class="nav-item" data-cy="app-header-url_women" label="WOMEN" :link="localePath('/c/women')"/>
+        <SfHeaderNavigationItem class="nav-item"  data-cy="app-header-url_men" label="MEN" :link="localePath('/c/men')" />
       </template>
       <template #aside>
         <LocaleSelector class="smartphone-only" />
@@ -116,7 +94,7 @@
 </template>
 
 <script>
-import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay, SfMenuItem } from '@storefront-ui/vue';
+import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay, SfMenuItem, SfLink } from '@storefront-ui/vue';
 import { useUiState } from '~/composables';
 import { useCart, useWishlist, useUser, cartGetters, useFacet } from '<%= options.generate.replace.composables %>';
 import { computed, ref, onBeforeUnmount, watch } from '@vue/composition-api';
@@ -142,7 +120,8 @@ export default {
     SfSearchBar,
     SearchResults,
     SfOverlay,
-    SfMenuItem
+    SfMenuItem,
+    SfLink
   },
   directives: { clickOutside },
   setup(props, { root }) {

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -12,8 +12,30 @@
         </nuxt-link>
       </template>
       <template #navigation>
-        <SfHeaderNavigationItem class="nav-item" data-cy="app-header-url_women" label="WOMEN" :link="localePath('/c/women')"/>
-        <SfHeaderNavigationItem class="nav-item"  data-cy="app-header-url_men" label="MEN" :link="localePath('/c/men')" />
+        <SfHeaderNavigationItem class="nav-item" data-cy="app-header-url_women" label="WOMEN" :link="localePath('/c/women')">
+          <!-- <template name="desktop-navigation-item">
+            <SfLink class="sf-header-navigation-item__link" :link="link">{{
+              label
+            }}</SfLink>
+          </template> -->
+
+          <template #mobile-navigation-item>
+            <SfMenuItem label="WOMEN" class="sf-header-navigation-item__menu-item">
+              <template #mobile-nav-icon>
+                &#8203;
+              </template>
+            </SfMenuItem>
+          </template>
+        </SfHeaderNavigationItem>
+        <SfHeaderNavigationItem class="nav-item"  data-cy="app-header-url_men" label="MEN" :link="localePath('/c/men')" >
+          <template #mobile-navigation-item>
+            <SfMenuItem label="MEN" class="sf-header-navigation-item__menu-item">
+              <template #mobile-nav-icon>
+                &#8203;
+              </template>
+            </SfMenuItem>
+          </template>
+        </SfHeaderNavigationItem>
       </template>
       <template #aside>
         <LocaleSelector class="smartphone-only" />
@@ -94,7 +116,7 @@
 </template>
 
 <script>
-import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay } from '@storefront-ui/vue';
+import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay, SfMenuItem } from '@storefront-ui/vue';
 import { useUiState } from '~/composables';
 import { useCart, useWishlist, useUser, cartGetters, useFacet } from '<%= options.generate.replace.composables %>';
 import { computed, ref, onBeforeUnmount, watch } from '@vue/composition-api';
@@ -119,7 +141,8 @@ export default {
     SfBadge,
     SfSearchBar,
     SearchResults,
-    SfOverlay
+    SfOverlay,
+    SfMenuItem
   },
   directives: { clickOutside },
   setup(props, { root }) {
@@ -230,6 +253,9 @@ export default {
 }
 .nav-item {
   --header-navigation-item-margin: 0 var(--spacer-base);
+  .sf-header-navigation-item__item--mobile {
+    display: none;
+  }
 }
 
 .cart-badge {

--- a/packages/core/nuxt-theme-module/theme/components/SearchResults.vue
+++ b/packages/core/nuxt-theme-module/theme/components/SearchResults.vue
@@ -8,6 +8,13 @@
       <transition name="sf-fade" mode="out-in">
         <div v-if="products.length > 0" class="search__wrapper-results" key="results">
           <SfMegaMenuColumn :title="$t('Categories')" class="sf-mega-menu-column--pined-content-on-mobile search__categories">
+            <template #title="{title}">
+              <SfMenuItem :label="title" @click="megaMenu.changeActive(title)">
+                <template #mobile-nav-icon>
+                  &#8203;
+                </template>
+              </SfMenuItem>
+            </template>
             <SfList>
               <SfListItem v-for="(category, key) in categories.items" :key="key">
                 <SfMenuItem :label="category.label" :link="`/c/women/${category.slug}`">
@@ -74,12 +81,8 @@
             <SfButton class="action-buttons__button color-light" @click="$emit('close')">{{ $t('Cancel') }}</SfButton>
           </div>
         </div>
-        <div v-else class="before-results" key="no-results">
-          <SfImage src="/error/error.svg" class="before-results__picture" alt="error">
-            <template #default>
-              &#8203;
-            </template>
-          </SfImage>
+        <div v-else key="no-results" class="before-results">
+          <SfImage src="/error/error.svg" class="before-results__picture" alt="error" loading="lazy"/>
           <p class="before-results__paragraph">{{ $t('You haven’t searched for items yet') }}</p>
           <p class="before-results__paragraph">{{ $t('Let’s start now – we’ll help you') }}</p>
           <SfButton class="before-results__button color-secondary smartphone-only" @click="$emit('close')">{{ $t('Go back') }}</SfButton>
@@ -148,9 +151,7 @@ export default {
   }
 };
 </script>
-
 <style lang="scss" scoped>
-
 .search {
   position: absolute;
   right: 0;
@@ -258,5 +259,4 @@ export default {
     width: 100%;
   }
 }
-
 </style>

--- a/packages/core/nuxt-theme-module/theme/components/SearchResults.vue
+++ b/packages/core/nuxt-theme-module/theme/components/SearchResults.vue
@@ -10,16 +10,21 @@
           <SfMegaMenuColumn :title="$t('Categories')" class="sf-mega-menu-column--pined-content-on-mobile search__categories">
             <SfList>
               <SfListItem v-for="(category, key) in categories.items" :key="key">
-                <SfMenuItem :label="category.label" :link="`/c/women/${category.slug}`"/>
+                <SfMenuItem :label="category.label" :link="`/c/women/${category.slug}`">
+                  <template #mobile-nav-icon>
+                    &#8203;
+                  </template>
+                </SfMenuItem>
               </SfListItem>
             </SfList>
           </SfMegaMenuColumn>
           <SfMegaMenuColumn :title="$t('Product suggestions')" class="sf-mega-menu-column--pined-content-on-mobile search__results">
             <template #title="{title}">
-              <SfMenuItem
-                :label="title"
-                class="sf-mega-menu-column__header search__header"
-              />
+              <SfMenuItem :label="title" class="sf-mega-menu-column__header search__header">
+                <template #mobile-nav-icon>
+                  &#8203;
+                </template>
+              </SfMenuItem>
             </template>
             <SfScrollable class="results--desktop desktop-only" show-text="" hide-text="">
               <div class="results-listing">
@@ -70,7 +75,11 @@
           </div>
         </div>
         <div v-else class="before-results" key="no-results">
-          <SfImage src="/error/error.svg" class="before-results__picture" alt="error"/>
+          <SfImage src="/error/error.svg" class="before-results__picture" alt="error">
+            <template #default>
+              &#8203;
+            </template>
+          </SfImage>
           <p class="before-results__paragraph">{{ $t('You haven’t searched for items yet') }}</p>
           <p class="before-results__paragraph">{{ $t('Let’s start now – we’ll help you') }}</p>
           <SfButton class="before-results__button color-secondary smartphone-only" @click="$emit('close')">{{ $t('Go back') }}</SfButton>


### PR DESCRIPTION
### Related Issues
closes #5744 

### Short Description of the PR
Fixes hydration error on category page in desktop mode. 
It's temporary solution, because it need to be fixed in SFUI by changing the wrapping div in SfIcon. It is a part of SfMenuItem and it causes html syntax bug - div inside button.  
There's an issue to resolve this problem in SFUI - [#1766](https://github.com/vuestorefront/storefront-ui/issues/1766)


However it looks like there is an error in mobile mode in HeaderNavigationItem, which I couldn't solve:
![image](https://user-images.githubusercontent.com/32042425/114454424-e4478400-9bda-11eb-8525-dc6f44fcb726.png)


But it only appears in dev mode.  


### Screenshots of Visual Changes before/after (if There Are Any)

Category page after fixing:

![image](https://user-images.githubusercontent.com/32042425/114452323-9df12580-9bd8-11eb-9284-3ae94f578e7d.png)


### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


