### PR TITLE
refactor: got rid of status event

### DIFF
--- a/packages/commercetools/theme/components/Checkout/VsfPaymentProviderMock.vue
+++ b/packages/commercetools/theme/components/Checkout/VsfPaymentProviderMock.vue
@@ -44,6 +44,7 @@ import {
   SfRadio
 } from '@storefront-ui/vue';
 import { ref } from '@vue/composition-api';
+import { usePaymentProviderMock } from '@/composables/usePaymentProviderMock';
 
 export default {
   name: 'VsfPaymentProviderMock',
@@ -52,7 +53,8 @@ export default {
     SfButton,
     SfRadio
   },
-  setup (_, context) {
+  setup () {
+    const { status } = usePaymentProviderMock();
     const selectedPaymentMethod = ref({});
     const paymentMethods = ref([
       {
@@ -64,7 +66,7 @@ export default {
 
     const selectPaymentMethod = paymentMethod => {
       selectedPaymentMethod.value = paymentMethod;
-      context.emit('status', true);
+      status.value = true;
     };
 
     return {

--- a/packages/commercetools/theme/composables/usePaymentProviderMock/index.ts
+++ b/packages/commercetools/theme/composables/usePaymentProviderMock/index.ts
@@ -1,0 +1,9 @@
+import { sharedRef } from '@vue-storefront/core';
+
+export const usePaymentProviderMock = () => {
+  const status = sharedRef(false, 'usePaymentProviderMock-status');
+
+  return {
+    status
+  };
+};

--- a/packages/commercetools/theme/pages/Checkout/Payment.vue
+++ b/packages/commercetools/theme/pages/Checkout/Payment.vue
@@ -105,7 +105,7 @@
           :value="$n(totals.total, 'currency')"
           class="sf-property--full-width sf-property--large property summary__property-total"
         />
-        <VsfPaymentProviderMock @status="paymentReady = $event"/>
+        <VsfPaymentProviderMock />
         <SfCheckbox v-e2e="'terms'" v-model="terms" name="terms" class="summary__terms">
           <template #label>
             <div class="sf-checkbox__label">
@@ -145,6 +145,7 @@ import { useMakeOrder, useCart, useBilling, useShipping, useShippingProvider, ca
 import { onSSR } from '@vue-storefront/core';
 import getShippingMethodPrice from '@/helpers/Checkout/getShippingMethodPrice';
 import VsfPaymentProviderMock from '@/components/Checkout/VsfPaymentProviderMock';
+import { usePaymentProviderMock } from '@/composables/usePaymentProviderMock';
 
 export default {
   name: 'ReviewOrder',
@@ -163,8 +164,7 @@ export default {
     VsfPaymentProviderMock
   },
   setup(_, context) {
-    const paymentReady = ref(false);
-    const terms = ref(false);
+    const { status: paymentReady } = usePaymentProviderMock();
     const { cart, removeItem, load, setCart } = useCart();
     const { shipping: shippingDetails, load: loadShippingDetails } = useShipping();
     const { load: loadShippingProvider, state } = useShippingProvider();
@@ -173,6 +173,8 @@ export default {
     const products = computed(() => cartGetters.getItems(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
     const { order, make, loading } = useMakeOrder();
+
+    const terms = ref(false);
 
     onSSR(async () => {
       await load();

--- a/packages/commercetools/theme/pages/Checkout/Shipping.vue
+++ b/packages/commercetools/theme/pages/Checkout/Shipping.vue
@@ -219,10 +219,21 @@
           </SfButton>
         </div>
       </div>
-      <VsfShippingProvider
-        v-if="isShippingDetailsStepCompleted && !dirty"
-        @submit="$router.push('/checkout/billing')"
-      />
+      <div v-if="isShippingDetailsStepCompleted && !dirty">
+        <VsfShippingProvider
+          @submit="$router.push('/checkout/billing')"
+        />
+        <div class="form__action">
+          <SfButton
+            class="form__action-button"
+            type="button"
+            @click.native="$router.push('/checkout/billing')"
+            :disabled="!isShippingMethodStepCompleted || loadingShippingProvider"
+          >
+            {{ $t('Continue to billing') }}
+          </SfButton>
+        </div>
+      </div>
     </form>
   </ValidationObserver>
 </template>
@@ -234,7 +245,7 @@ import {
   SfButton,
   SfSelect
 } from '@storefront-ui/vue';
-import { useUserShipping, userShippingGetters, useUser, useShipping } from '@vue-storefront/commercetools';
+import { useShippingProvider, useUserShipping, userShippingGetters, useUser, useShipping } from '@vue-storefront/commercetools';
 import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
 import { required, min, digits } from 'vee-validate/dist/rules';
 import { useVSFContext } from '@vue-storefront/core';
@@ -283,6 +294,11 @@ export default {
     const isShippingDetailsStepCompleted = ref(false);
 
     const canMoveForward = computed(() => !loading.value && shippingDetails.value && Object.keys(shippingDetails.value).length);
+
+    const {
+      state,
+      loading: loadingShippingProvider
+    } = useShippingProvider();
 
     const hasSavedShippingAddress = computed(() => {
       if (!isAuthenticated.value || !userShipping.value) {
@@ -398,7 +414,10 @@ export default {
       loading,
 
       isShippingDetailsStepCompleted,
-      canMoveForward
+      canMoveForward,
+
+      isShippingMethodStepCompleted: computed(() => state.value && state.value._status),
+      loadingShippingProvider
     };
   }
 };

--- a/packages/commercetools/theme/pages/Checkout/Shipping.vue
+++ b/packages/commercetools/theme/pages/Checkout/Shipping.vue
@@ -220,9 +220,7 @@
         </div>
       </div>
       <div v-if="isShippingDetailsStepCompleted && !dirty">
-        <VsfShippingProvider
-          @submit="$router.push('/checkout/billing')"
-        />
+        <VsfShippingProvider />
         <div class="form__action">
           <SfButton
             class="form__action-button"

--- a/packages/commercetools/theme/pages/Checkout/Shipping.vue
+++ b/packages/commercetools/theme/pages/Checkout/Shipping.vue
@@ -223,6 +223,7 @@
         <VsfShippingProvider />
         <div class="form__action">
           <SfButton
+            v-e2e="'continue-to-billing'"
             class="form__action-button"
             type="button"
             @click.native="$router.push('/checkout/billing')"

--- a/packages/core/docs/guide/checkout.md
+++ b/packages/core/docs/guide/checkout.md
@@ -294,16 +294,14 @@ export default {
 ### SDK allows externalizing pay method
 
 If the payment provider's SDK handles the process of configuring payment but allows you to decide when to finalize then:
-- VsfPaymentProvider emits `status` event. Use this information to enable/disable a `Place order` button.
 - Composable shares a `pay` method.
+- Composable shares a `status` boolean ref that informs if you are ready to call `pay`.
 
 ```vue
 <template>
   <div>
-    <VsfPaymentProvider
-      @status="readyToPay = $event"
-    />
-    <button @click="makeOrder" :disabled="!readyToPay">
+    <VsfPaymentProvider />
+    <button @click="makeOrder" :disabled="!status">
       {{ $t('Order and Pay') }}
     </button>
   </div>
@@ -317,9 +315,8 @@ import { useMakeOrder } from '{INTEGRATION}';
 export default {
   // ...
   setup () {
-    const readyToPay = ref(false);
     const { make } = useMakeOrder();
-    const { pay } = usePaymentProvider();
+    const { pay, status } = usePaymentProvider();
 
     const makeOrder = () => {
       await make();
@@ -328,7 +325,7 @@ export default {
 
     return {
       makeOrder,
-      readyToPay
+      status
     };
   }
 }

--- a/packages/core/docs/guide/checkout.md
+++ b/packages/core/docs/guide/checkout.md
@@ -77,12 +77,10 @@ The component is responsible for:
 All you have to do is to import a component and add it to the template.
 
 ```vue
-<VsfShippingProvider
-  @submit="$router.push('/checkout/billing')"
-/>
+<VsfShippingProvider />
 ```
 
-`VsfShippingProvider` emits the `submit` event when a shipping method is selected, configured and a user clicks submit button.
+`VsfShippingProvider` sets `state.value._status` property of `useShippingProvider` to `true` or `false`. The property informs whether a user is ready to go to the next step (`true`) or not (`false`).
 
 ### Extending `VsfShippingProvider` and reacting to its events
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5750 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
VsfPaymentProvider uses sharedRef `status` from `usePaymentProviderMock` composable. I've decided to put it in the theme because I imagine the developer will either modify it or replace it with a dedicated module like adyen.

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [x] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


