### PR TITLE
Add e2e tests workflows

### DIFF
--- a/.github/workflows/run-e2e-regression.yml
+++ b/.github/workflows/run-e2e-regression.yml
@@ -1,0 +1,61 @@
+name: Run E2E Regression Tests
+on:
+  schedule:
+    - cron: "0 0 * * 1-5"
+jobs:
+  run_e2e_tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ["ct", "bp"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: next
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Get cached dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/Cypress
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build tools
+        run: yarn build:${{ matrix.package }}
+
+      - name: Run cypress tests
+        uses: cypress-io/github-action@v2.8.2
+        with:
+          start: yarn dev:${{ matrix.package }}
+          wait-on: 'http://localhost:3000'
+          command: yarn run test:e2e:${{ matrix.package }}:hl
+          browser: chrome
+          headless: true
+          install: false
+        env:
+          CYPRESS_INCLUDE_TAGS: regression
+
+      - name: Generate report
+        if: ${{ always() }}
+        run: yarn test:e2e:${{ matrix.package }}:generate:report
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: report
+          path: "packages/$${{ matrix.package }}/theme/tests/e2e/report"
+        env:
+          bp: boilerplate
+          ct: commercetools

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,71 @@
+name: Run E2E Tests
+on:
+  workflow_dispatch:
+    inputs:
+      tags_include:
+        description: "Include tags"
+        required: false
+      tags_exclude:
+        description: "Exclude tags"
+        required: false
+      package:
+        description: "Package"
+        default: "ct"
+        required: true
+      browser:
+        description: "Browser"
+        default: "chrome"
+        required: true
+jobs:
+  run_e2e_tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Get cached dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/Cypress
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build tools
+        run: yarn build:${{ github.event.inputs.package }}
+
+      - name: Run cypress tests
+        uses: cypress-io/github-action@v2.8.2
+        with:
+          start: yarn dev:${{ github.event.inputs.package }}
+          wait-on: 'http://localhost:3000'
+          command: yarn run test:e2e:${{ github.event.inputs.package }}:hl
+          browser: ${{ github.event.inputs.browser }}
+          headless: true
+          install: false
+        env:
+          CYPRESS_INCLUDE_TAGS: ${{ github.event.inputs.tags_include }}
+          CYPRESS_EXCLUDE_TAGS: ${{ github.event.inputs.tags_exclude }}
+
+      - name: Generate report
+        if: ${{ always() }}
+        run: yarn test:e2e:${{ github.event.inputs.tags_exclude }}:generate:report
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: report
+          path: "packages/$${{ github.event.inputs.package }}/theme/tests/e2e/report"
+        env:
+          bp: boilerplate
+          ct: commercetools


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5762 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Adds github action workflows for running e2e tests, both triggered manually and scheduled regression suite.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


