### PR TITLE
fix: theme folder name constraint

### DIFF
--- a/packages/core/nuxt-theme-module/generate.js
+++ b/packages/core/nuxt-theme-module/generate.js
@@ -33,11 +33,12 @@ export default async function ({
 
   log.info('Adding theme files...');
 
+  const themeFolderName = this.options.srcDir.split(path.sep).pop()
   const themeDirectoriesPaths = getAllSubDirs(this.options.rootDir, [targetDirectory, '.nuxt', 'node_modules', 'test'])
     .map(directory => path.join(this.options.rootDir, directory));
 
   await Promise.all(agnosticThemeFiles.map(path => compileAgnosticTemplate(path)));
-  await Promise.all(themeDirectoriesPaths.map(absolutePath => copyThemeFiles(absolutePath)));
+  await Promise.all(themeDirectoriesPaths.map(absolutePath => copyThemeFiles(absolutePath, themeFolderName)));
 
   log.success(`Added ${agnosticThemeFiles.length} theme file(s) to ${chalk.bold(targetDirectory)} folder`);
 

--- a/packages/core/nuxt-theme-module/scripts/copyThemeFiles.js
+++ b/packages/core/nuxt-theme-module/scripts/copyThemeFiles.js
@@ -10,13 +10,13 @@ async function copyFile(fileDir, outDir) {
   return fs.writeFileSync(outDir, data);
 }
 
-function copyThemeFile(themePath) {
-  return copyFile(themePath, themePath.replace(path.sep + 'theme' + path.sep, path.sep + 'theme' + path.sep + '_theme' + path.sep));
+function copyThemeFile(themePath, themeFolderName) {
+  return copyFile(themePath, themePath.replace(path.sep + themeFolderName + path.sep, path.sep + themeFolderName + path.sep + '_theme' + path.sep));
 }
 
-function copyThemeFiles(filesDir) {
+function copyThemeFiles(filesDir, themeFolderName) {
   return Promise.all(getAllFilesFromDir(filesDir).map(
-    file => copyThemeFile(file)
+    file => copyThemeFile(file, themeFolderName)
   ));
 }
 


### PR DESCRIPTION
### Short Description of the PR
`"@vue-storefront/nuxt-theme"` theme inheritance will work correctly if theme root folder name is **"theme"**. Otherwise it does not overwrite files from agnostic theme in `@vue-storefront/nuxt-theme/theme`. Fix removes this constraint and provides ability to have multiple theme folders with different names that can inherit from `@vue-storefront/nuxt-theme/theme`.



