### PR TITLE
ci: exclude changelog from docs label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,9 +14,9 @@ commercetools:
 boilerplate:
 - packages/boilerplate/**/*
 
-# Add 'docs' label to any change to packages/core/docs files
+# Add 'docs' label to any change to packages/core/docs files EXCEPT for the changelog
 docs:
-- packages/core/docs/**/*
+- any: ['packages/core/docs/**/*', '!packages/core/docs/changelog/**/*']
 
 # Add 'ci' label to any change to continuous integration files inside .github folder
 ci:


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


