### PR TITLE
Add migration guide for 2.3.0-rc.3 and 2.3.0

### DIFF
--- a/packages/core/docs/.vuepress/config.js
+++ b/packages/core/docs/.vuepress/config.js
@@ -31,11 +31,27 @@ module.exports = {
 		sidebar: {
 			'/migrate/': [
 				{
-					title: 'Migration guide 2.3.0-rc.1',
+					title: 'Migration guide 2.3.0',
 					children: [
-						['/migrate/2.3.0-rc.1/overview', 'Overview'],
-						['/migrate/2.3.0-rc.1/integrators', 'Integrators'],
-						['/migrate/2.3.0-rc.1/commercetools', 'commercetools']
+						['/migrate/2.3.0/overview', 'Overview'],
+						['/migrate/2.3.0/integrators', 'Integrators'],
+						['/migrate/2.3.0/commercetools', 'commercetools']
+					]
+				},
+				{
+					title: 'Migration guide 2.3.0-rc.3',
+					children: [
+						['/migrate/2.3.0-rc.3/overview', 'Overview'],
+						['/migrate/2.3.0-rc.3/integrators', 'Integrators'],
+						['/migrate/2.3.0-rc.3/commercetools', 'commercetools']
+					]
+				},
+				{
+					title: 'Migration guide 2.3.0-rc.2',
+					children: [
+						['/migrate/2.3.0-rc.2/overview', 'Overview'],
+						['/migrate/2.3.0-rc.2/integrators', 'Integrators'],
+						['/migrate/2.3.0-rc.2/commercetools', 'commercetools']
 					]
 				},
 				{

--- a/packages/core/docs/migrate/2.3.0-rc.2/commercetools.md
+++ b/packages/core/docs/migrate/2.3.0-rc.2/commercetools.md
@@ -1,14 +1,14 @@
-# Migration guide 2.3.0-rc.1 for commercetools
+# Migration guide 2.3.0-rc.2 for commercetools
 
 ## Introduction
 
-This is a migration guide meant to help developers using our `commercetools` integration to upgrade to a new version 2.3.0-rc.1.
+This migration guide helps developers using our `commercetools` integration to upgrade to version 2.3.0-rc.2.
 
-For more information about the new version, please refer to the [Overview](./overview.md) page.
+For more information about this version, refer to the [Overview](./overview.md) page.
 
 ## Changes
 
-We also made changes to the following files:
+We made changes to the following files:
 - added new composable `useBilling`,
 - added new composable `useShipping`,
 - added new composable `useShippingProvider`

--- a/packages/core/docs/migrate/2.3.0-rc.2/integrators.md
+++ b/packages/core/docs/migrate/2.3.0-rc.2/integrators.md
@@ -1,10 +1,10 @@
-# Migration guide 2.3.0-rc.1 for Integrators
+# Migration guide 2.3.0-rc.2 for Integrators
 
 ## Introduction
 
-This is a migration guide meant to help Integrators make their integrations and plugins compatible with a new version 2.3.0-rc.1.
+This migration guide helps Integrators make their integrations and plugins compatible with version 2.3.0-rc.2.
 
-It only contains code examples. For more information about the new version, please refer to the [Overview](./overview.md) page.
+It only contains code examples. For more information about this version, refer to the [Overview](./overview.md) page.
 
 ## API middleware
 

--- a/packages/core/docs/migrate/2.3.0-rc.2/overview.md
+++ b/packages/core/docs/migrate/2.3.0-rc.2/overview.md
@@ -1,4 +1,6 @@
-# Migration guide 2.3.0-rc.1
+# Migration guide 2.3.0-rc.2
+
+## Introduction
 
 In this release, we introduced few new APIs but also some breaking changes.
 

--- a/packages/core/docs/migrate/2.3.0-rc.3/commercetools.md
+++ b/packages/core/docs/migrate/2.3.0-rc.3/commercetools.md
@@ -1,0 +1,18 @@
+# Migration guide 2.3.0-rc.3 for commercetools
+
+## Introduction
+
+This migration guide helps developers using our `commercetools` integration to upgrade to version 2.3.0-rc.3.
+
+For more information about this version, refer to the [Overview](./overview.md) page.
+
+## Changes
+
+- Fixed mapping for product attributes with type `set`.
+- Fixed cart getters to not throw errors when some properties are missing.
+- Fixed error thrown by the Composition API plugin when importing `useWishlist`.
+
+We also made changes to the following files:
+- updated `components/Checkout/VsfShippingProvider.vue`,
+- deleted unused `packages/commercetools/theme/helpers/filters/getFiltersForUrl.js`,
+- deleted unused `packages/commercetools/theme/helpers/filters/getFiltersFromUrl.js`.

--- a/packages/core/docs/migrate/2.3.0-rc.3/integrators.md
+++ b/packages/core/docs/migrate/2.3.0-rc.3/integrators.md
@@ -1,0 +1,25 @@
+# Migration guide 2.3.0-rc.3 for Integrators
+
+## Introduction
+
+This migration guide helps Integrators make their integrations and plugins compatible with version 2.3.0-rc.3.
+
+It only contains code examples. For more information about this version, refer to the [Overview](./overview.md) page.
+
+## Changes
+
+- Added `extendApp` to Server Middleware extensions (`ApiClientExtension` interface). It allows direct access to the Express server instance.
+
+```typescript
+export const customExtension = {
+  name: 'customExtension',
+
+  extendApp: (app: Express) => {
+    app.use(customPlugin());
+
+    app.get('/customEndpoint', customMiddleware(), (request, response) => {
+      //
+    });
+  }
+};
+```

--- a/packages/core/docs/migrate/2.3.0-rc.3/overview.md
+++ b/packages/core/docs/migrate/2.3.0-rc.3/overview.md
@@ -1,0 +1,18 @@
+# Migration guide 2.3.0-rc.3
+
+## Introduction
+
+This release mainly contains bug fixes and some new features, as we are getting closer to the stable 2.3.0 release.
+
+## Changes
+
+- Fixed `error` property clearing in `useUser`.
+- Improved error handling in Server Middleware. When the request to the external backend fails, Server Middleware now returns `HTTP 500` code with the error message in the body.
+- Added `extendApp` to Server Middleware extensions (`ApiClientExtension` interface). It allows direct access to the Express server instance.
+  
+We also made changes to the following files:
+- updated `components/LoginModal.vue`,
+- updated `layouts/default.vue`,
+- removed unused `helpers/filters/getFiltersForUrl.js`,
+- removed unused `helpers/filters/getFiltersFromUrl.js`,
+- removed unused `helpers/filters/index.js`.

--- a/packages/core/docs/migrate/2.3.0/commercetools.md
+++ b/packages/core/docs/migrate/2.3.0/commercetools.md
@@ -1,0 +1,33 @@
+# Migration guide 2.3.0 for commercetools
+
+## Introduction
+
+This migration guide helps developers using our `commercetools` integration to upgrade to version 2.3.0.
+
+For more information about this version, refer to the [Overview](./overview.md) page.
+
+## Changes
+
+
+- Added E2E (cypress) tests:
+  - use `yarn test:e2e` to start Cypress,
+  - use `test:e2e:hl` to run Cypress tests in headless mode. Useful for running the tests in CI/CD workflows,
+  - use `test:e2e:generate:report` to generate Cypress report.
+- **[BREAKING]** Fixed helpers used for search on the Category page to read `phrase` URL query string instead of `term`.
+- Added `SfLoader` to `VsfShippingProvider` to correctly handle the loading state.
+- Added expiration time to `vsf-commercetools-token` cookie matching token expiration time received from commercetools. Previously session cookies were used, which browsers delete when the current session ends. This forced users to log in more often than necessary.
+
+We also made changes to the following files:
+- updated `components/Checkout/CartPreview.vue`,
+- updated `components/Checkout/UserBillingAddresses.vue`,
+- updated `components/Checkout/UserShippingAddresses.vue`,
+- updated `components/Checkout/VsfPaymentProviderMock.vue`,
+- updated `components/Checkout/VsfShippingProvider.vue`,
+- updated `components/MyAccount/BillingAddressForm.vue`,
+- updated `components/MyAccount/PasswordResetForm.vue`,
+- updated `components/MyAccount/ProfileUpdateForm.vue`,
+- updated `components/MyAccount/ShippingAddressForm.vue`,
+- updated `pages/Checkout/Billing.vue`,
+- updated `pages/Checkout/Payment.vue`,
+- updated `pages/Checkout/Shipping.vue`,
+- updated `pages/Checkout/ThankYou.vue`.

--- a/packages/core/docs/migrate/2.3.0/commercetools.md
+++ b/packages/core/docs/migrate/2.3.0/commercetools.md
@@ -15,6 +15,7 @@ For more information about this version, refer to the [Overview](./overview.md) 
 - **[BREAKING]** Fixed helpers used for search on the Category page to read `phrase` URL query string instead of `term`.
 - Added `SfLoader` to `VsfShippingProvider` to correctly handle the loading state.
 - Added expiration time to `vsf-commercetools-token` cookie matching token expiration time received from commercetools. Previously session cookies were used, which browsers delete when the current session ends. This forced users to log in more often than necessary.
+- Fixed an issue in the cart where API calls would result in `HTTP 413 Payload Too Large` error code due to large payload size. Cart method calls will now only include cart `id` and `version` instead of the whole cart object.
 
 We also made changes to the following files:
 - updated `components/Checkout/CartPreview.vue`,

--- a/packages/core/docs/migrate/2.3.0/commercetools.md
+++ b/packages/core/docs/migrate/2.3.0/commercetools.md
@@ -8,7 +8,6 @@ For more information about this version, refer to the [Overview](./overview.md) 
 
 ## Changes
 
-
 - Added E2E (cypress) tests:
   - use `yarn test:e2e` to start Cypress,
   - use `test:e2e:hl` to run Cypress tests in headless mode. Useful for running the tests in CI/CD workflows,

--- a/packages/core/docs/migrate/2.3.0/integrators.md
+++ b/packages/core/docs/migrate/2.3.0/integrators.md
@@ -1,0 +1,27 @@
+# Migration guide 2.3.0 for Integrators
+
+## Introduction
+
+This migration guide helps Integrators make their integrations and plugins compatible with version 2.3.0.
+
+It only contains code examples. For more information about this version, refer to the [Overview](./overview.md) page.
+
+## Changes
+
+- Added E2E (cypress) tests to `boilerplate` theme.
+
+- **[BREAKING]** Changed the signature of `extendApp` in Server Middleware extensions introduced in the previous release from `extendApp(app)` to `extendApp({ app, configuration })`
+
+```typescript
+export const customExtension = {
+  name: 'customExtension',
+
+  extendApp: ({ app, configuration }: { app: Express, configuration: any }) => {
+    app.use(customPlugin(configuration));
+
+    app.get('/customEndpoint', customMiddleware(), (request, response) => {
+      //
+    });
+  }
+};
+```

--- a/packages/core/docs/migrate/2.3.0/overview.md
+++ b/packages/core/docs/migrate/2.3.0/overview.md
@@ -12,6 +12,7 @@ In this release, we focused on bug fixes and test coverage but also introduced f
 - Added new `v-e2e` directive. It adds `data-e2e` attribute to the element in development mode or when app is ran with `NUXT_ENV_E2E` environment variable and can be used as selectors for E2E tests.
 - Added E2E (cypress) tests.
 - Updated Storefront UI to the latest version.
+- Fix hydration bug on the Category page.
 - Added support for custom queries in methods in `useUserBilling` and `useUserShipping` composables.
 - **[BREAKING]** Added `changeToCategoryListView` and renamed `toggleCategoryGridView` to `changeToCategoryGridView` in `composables/useUiState.ts`.
 

--- a/packages/core/docs/migrate/2.3.0/overview.md
+++ b/packages/core/docs/migrate/2.3.0/overview.md
@@ -1,0 +1,48 @@
+# Migration guide 2.3.0
+
+## Introduction
+
+This release is the first one we officially call **Vue Storefront 2** (previously Vue Storefront Next). We hosted Vue Storefront Summit 2021, which you can learn more about [in our blog post](https://blog.vuestorefront.io/vue-storefront-summit-2021-short-summary-and-every-video/).
+During the Summit, we announced many new eCommerce integrations and move from Slack to Discord server. [Join us](https://discord.vuestorefront.io/) to stay up-to-date and ask for help.
+
+In this release, we focused on bug fixes and test coverage but also introduced few changes.
+
+## Changes
+
+- Added new `v-e2e` directive. It adds `data-e2e` attribute to the element in development mode or when app is ran with `NUXT_ENV_E2E` environment variable and can be used as selectors for E2E tests.
+- Added E2E (cypress) tests.
+- Updated Storefront UI to the latest version.
+- Added support for custom queries in methods in `useUserBilling` and `useUserShipping` composables.
+- **[BREAKING]** Added `changeToCategoryListView` and renamed `toggleCategoryGridView` to `changeToCategoryGridView` in `composables/useUiState.ts`.
+
+We also made changes to the following files:
+- updated `components/AppFooter.vue`,
+- updated `components/AppHeader.vue`,
+- updated `components/BottomNavigation.vue`,
+- updated `components/CartSidebar.vue`,
+- updated `components/Checkout/VsfPaymentProvider.vue`,
+- updated `components/Checkout/VsfShippingProvider.vue`,
+- updated `components/LocaleSelector.vue`,
+- updated `components/LoginModal.vue`,
+- updated `components/RelatedProducts.vue`,
+- updated `components/SearchResults.vue`,
+- updated `components/TopBar.vue`,
+- updated `components/WishlistSidebar.vue`,
+- updated `layouts/account.vue`,
+- updated `layouts/default.vue`,
+- updated `layouts/error.vue`,
+- updated `pages/Category.vue`,
+- updated `pages/Checkout/Billing.vue`,
+- updated `pages/Checkout/Payment.vue`,
+- updated `pages/Checkout/Shipping.vue`,
+- updated `pages/Checkout/ThankYou.vue`,
+- updated `pages/Home.vue`,
+- updated `pages/MyAccount.vue`,
+- updated `pages/MyAccount/BillingDetails.vue`,
+- updated `pages/MyAccount/LoyaltyCard.vue`,
+- updated `pages/MyAccount/MyNewsletter.vue`,
+- updated `pages/MyAccount/MyProfile.vue`,
+- updated `pages/MyAccount/MyReviews.vue`,
+- updated `pages/MyAccount/OrderHistory.vue`,
+- updated `pages/MyAccount/ShippingDetails.vue`,
+- updated `pages/Product.vue`.

--- a/packages/core/docs/migrate/index.md
+++ b/packages/core/docs/migrate/index.md
@@ -1,5 +1,7 @@
 # Migration guides
 
-- [2.3.0-rc.1](./2.3.0-rc.1/overview.md)
+- [2.3.0](./2.3.0/overview.md)
+- [2.3.0-rc.3](./2.3.0-rc.3/overview.md)
+- [2.3.0-rc.2](./2.3.0-rc.2/overview.md)
 - [2.2.0](./2.2.0/overview.md)
 - [2.1.0-rc.1](./2.1.0-rc.1/overview.md)


### PR DESCRIPTION
### Short Description of the PR
* rename migration guide from `rc.1` to `rc.2` to match changelog and branches in our repo,
* add migration guide for `2.3.0-rc.3` which was not created earlier,
* add migration guide for `2.3.0`.
