### PR TITLE
Reduce payload size for cart methods

### DIFF
--- a/packages/commercetools/api-client/src/api/addToCart/index.ts
+++ b/packages/commercetools/api-client/src/api/addToCart/index.ts
@@ -1,12 +1,12 @@
 import { CustomQuery } from '@vue-storefront/core';
 import updateCart from './../updateCart';
-import { CartResponse } from './../../types/Api';
-import { Cart, ProductVariant } from './../../types/GraphQL';
+import { CartDetails, CartResponse } from './../../types/Api';
+import { ProductVariant } from './../../types/GraphQL';
 import { createAddLineItemAction } from './../../helpers/cart/actions';
 
 const addToCart = async (
   settings,
-  { id, version }: Cart,
+  { id, version }: CartDetails,
   product: ProductVariant,
   quantity: number,
   customQuery?: CustomQuery

--- a/packages/commercetools/api-client/src/api/applyCartCoupon/index.ts
+++ b/packages/commercetools/api-client/src/api/applyCartCoupon/index.ts
@@ -1,18 +1,17 @@
 import { CustomQuery } from '@vue-storefront/core';
 import updateCart from '../updateCart';
-import { CartResponse } from '../../types/Api';
-import { Cart } from '../../types/GraphQL';
+import { CartDetails, CartResponse } from '../../types/Api';
 import { addDiscountCodeAction } from '../../helpers/cart/actions';
 
 const applyCartCoupon = async (
   settings,
-  cart: Cart,
+  { id, version }: CartDetails,
   discountCode: string,
   customQuery?: CustomQuery
 ): Promise<CartResponse> => {
   return await updateCart(settings, {
-    id: cart.id,
-    version: cart.version,
+    id,
+    version,
     actions: [addDiscountCodeAction(discountCode)]
   }, customQuery);
 };

--- a/packages/commercetools/api-client/src/api/removeCartCoupon/index.ts
+++ b/packages/commercetools/api-client/src/api/removeCartCoupon/index.ts
@@ -1,18 +1,18 @@
 import { CustomQuery } from '@vue-storefront/core';
 import updateCart from '../updateCart';
-import { CartResponse } from '../../types/Api';
-import { Cart, ReferenceInput } from '../../types/GraphQL';
+import { CartDetails, CartResponse } from '../../types/Api';
+import { ReferenceInput } from '../../types/GraphQL';
 import { removeDiscountCodeAction } from '../../helpers/cart/actions';
 
 const removeCartCoupon = async (
   context,
-  cart: Cart,
+  { id, version }: CartDetails,
   discountCode: ReferenceInput,
   customQuery?: CustomQuery
 ): Promise<CartResponse> => {
   return await updateCart(context, {
-    id: cart.id,
-    version: cart.version,
+    id,
+    version,
     actions: [removeDiscountCodeAction(discountCode)]
   }, customQuery);
 };

--- a/packages/commercetools/api-client/src/api/removeFromCart/index.ts
+++ b/packages/commercetools/api-client/src/api/removeFromCart/index.ts
@@ -1,15 +1,20 @@
 import { CustomQuery } from '@vue-storefront/core';
 import updateCart from './../updateCart';
-import { CartResponse } from './../../types/Api';
-import { Cart, LineItem } from './../../types/GraphQL';
+import { CartDetails, CartResponse } from './../../types/Api';
+import { LineItem } from './../../types/GraphQL';
 import { createRemoveLineItemAction } from './../../helpers/cart/actions';
 
-const removeFromCart = async (context, cart: Cart, product: LineItem, customQuery?: CustomQuery): Promise<CartResponse> => {
+const removeFromCart = async (
+  context,
+  { id, version }: CartDetails,
+  product: LineItem,
+  customQuery?: CustomQuery
+): Promise<CartResponse> => {
   return await updateCart(
     context,
     {
-      id: cart.id,
-      version: cart.version,
+      id,
+      version,
       actions: [createRemoveLineItemAction(product)]
     },
     customQuery

--- a/packages/commercetools/api-client/src/api/updateCartQuantity/index.ts
+++ b/packages/commercetools/api-client/src/api/updateCartQuantity/index.ts
@@ -1,20 +1,20 @@
 import { CustomQuery } from '@vue-storefront/core';
 import updateCart from '../updateCart';
-import { CartResponse } from '../../types/Api';
-import { Cart, LineItem } from '../../types/GraphQL';
+import { CartDetails, CartResponse } from '../../types/Api';
+import { LineItem } from '../../types/GraphQL';
 import { createChangeLineItemQuantityAction } from '../../helpers/cart/actions';
 
 const updateCartQuantity = async (
   context,
-  cart: Cart,
+  { id, version }: CartDetails,
   product: LineItem,
   customQuery?: CustomQuery
 ): Promise<CartResponse> => {
   return await updateCart(
     context,
     {
-      id: cart.id,
-      version: cart.version,
+      id,
+      version,
       actions: [createChangeLineItemQuantityAction(product)]
     },
     customQuery

--- a/packages/commercetools/api-client/src/types/Api.ts
+++ b/packages/commercetools/api-client/src/types/Api.ts
@@ -96,10 +96,11 @@ export type OrderResponse = OrderQueryResponse | OrderMutationResponse;
 export type ShippingMethodsResponse = QueryResponse<'shippingMethods', ShippingMethod>;
 export type SignInResponse = QueryResponse<'user', CustomerSignInResult>;
 export type ChangeMyPasswordResponse = QueryResponse<'user', Customer>;
+export type CartDetails = Pick<Cart, 'id' | 'version'>;
 
 interface ApiMethods {
-  addToCart ({ id, version }: Cart, product: ProductVariant, quantity: number): Promise<CartResponse>;
-  applyCartCoupon (cart: Cart, discountCode: string): Promise<CartResponse>;
+  addToCart ({ id, version }: CartDetails, product: ProductVariant, quantity: number): Promise<CartResponse>;
+  applyCartCoupon ({ id, version }: CartDetails, discountCode: string): Promise<CartResponse>;
   createCart (cartDraft?: CartData): Promise<{ data: CartQueryInterface }>;
   createMyOrderFromCart (draft: OrderMyCartCommand): Promise<OrderMutationResponse>;
   customerChangeMyPassword (version: any, currentPassword: string, newPassword: string): Promise<ChangeMyPasswordResponse>;
@@ -113,10 +114,10 @@ interface ApiMethods {
   getOrders (params): Promise<{ data: { me: Me } }>;
   getProduct (params): Promise<QueryResponse<'products', ProductQueryResult>>;
   getShippingMethods (cartId?: string): Promise<ShippingMethodData>;
-  removeCartCoupon (cart: Cart, discountCode: ReferenceInput): Promise<CartResponse>;
-  removeFromCart (cart: Cart, product: LineItem): Promise<CartResponse>;
+  removeCartCoupon ({ id, version }: CartDetails, discountCode: ReferenceInput): Promise<CartResponse>;
+  removeFromCart ({ id, version }: CartDetails, product: LineItem): Promise<CartResponse>;
   updateCart (params: UpdateCartParams): Promise<CartResponse>;
-  updateCartQuantity (cart: Cart, product: LineItem): Promise<CartResponse>;
+  updateCartQuantity ({ id, version }: CartDetails, product: LineItem): Promise<CartResponse>;
   updateShippingDetails (cart: Cart, shippingDetails: Address): Promise<CartResponse>;
   isGuest: () => boolean;
 }

--- a/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
+++ b/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
@@ -29,10 +29,11 @@ describe('[commercetools-composables] useCart', () => {
 
   it('adds to cart', async () => {
     const { addItem } = useCart() as any;
-    const response = await addItem(context, { currentCart: 'current cart', product: 'product1', quantity: 3 });
+    const currentCart = { id: 1, version: 1 };
+    const response = await addItem(context, { currentCart, product: 'product1', quantity: 3 });
 
     expect(response).toEqual('some cart');
-    expect(context.$ct.api.addToCart).toBeCalledWith('current cart', 'product1', 3, customQuery);
+    expect(context.$ct.api.addToCart).toBeCalledWith(currentCart, 'product1', 3, customQuery);
   });
 
   it('creates a new cart and add an item', async () => {
@@ -42,39 +43,43 @@ describe('[commercetools-composables] useCart', () => {
     expect(loadCurrentCart).toBeCalled();
 
     expect(response).toEqual('some cart');
-    expect(context.$ct.api.addToCart).toBeCalledWith('some cart', 'product1', 3, customQuery);
+    expect(context.$ct.api.addToCart).toBeCalledWith({ id: undefined, version: undefined }, 'product1', 3, customQuery);
   });
 
   it('removes from cart', async () => {
     const { removeItem } = useCart() as any;
-    const response = await removeItem(context, { currentCart: 'current cart', product: 'product1' });
+    const currentCart = { id: 1, version: 1 };
+    const response = await removeItem(context, { currentCart, product: 'product1' });
 
     expect(response).toEqual('some cart');
-    expect(context.$ct.api.removeFromCart).toBeCalledWith('current cart', 'product1', customQuery);
+    expect(context.$ct.api.removeFromCart).toBeCalledWith(currentCart, 'product1', customQuery);
   });
 
   it('updates quantity', async () => {
     const { updateItemQty } = useCart() as any;
+    const currentCart = { id: 1, version: 1 };
     const response = await updateItemQty(context, {
-      currentCart: 'current cart',
+      currentCart,
       product: { name: 'product1' },
       quantity: 5
     });
 
     expect(response).toEqual('some cart');
-    expect(context.$ct.api.updateCartQuantity).toBeCalledWith('current cart', { name: 'product1', quantity: 5 }, customQuery);
+    expect(context.$ct.api.updateCartQuantity).toBeCalledWith(currentCart, { name: 'product1', quantity: 5 }, customQuery);
   });
 
   it('clears cart', async () => {
     const { clear } = useCart() as any;
-    const response = await clear(context, { currentCart: 'current cart' });
+    const currentCart = { id: 1, version: 1 };
+    const response = await clear(context, { currentCart });
 
-    expect(response).toEqual('current cart');
+    expect(response).toEqual(currentCart);
   });
 
   it('applies coupon', async () => {
     const { applyCoupon } = useCart() as any;
-    const response = await applyCoupon(context, { currentCart: 'current cart', coupon: 'X123' });
+    const currentCart = { id: 1, version: 1 };
+    const response = await applyCoupon(context, { currentCart, coupon: 'X123' });
 
     expect(response).toEqual({ updatedCart: 'some cart' });
   });

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -1,5 +1,6 @@
-import { ProductVariant, Cart, LineItem } from './../types/GraphQL';
 import loadCurrentCart from './currentCart';
+import { ProductVariant, LineItem } from './../types/GraphQL';
+import { CartDetails } from '@vue-storefront/commercetools-api';
 import { AgnosticCoupon, useCartFactory, UseCartFactoryParams, Context } from '@vue-storefront/core';
 
 const getBasketItemByProduct = ({ currentCart, product }) => {
@@ -7,15 +8,13 @@ const getBasketItemByProduct = ({ currentCart, product }) => {
 };
 
 /** returns current cart or creates new one **/
-const getCurrentCart = async (context: Context, currentCart) => {
-  if (!currentCart) {
-    return loadCurrentCart(context);
-  }
+const getCurrentCartDetails = async (context: Context, currentCart): Promise<CartDetails> => {
+  const { id, version } = currentCart || await loadCurrentCart(context);
 
-  return currentCart;
+  return { id, version };
 };
 
-const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, AgnosticCoupon> = {
+const params: UseCartFactoryParams<CartDetails, LineItem, ProductVariant, AgnosticCoupon> = {
   load: async (context: Context, { customQuery }) => {
     const { $ct } = context;
 
@@ -30,36 +29,36 @@ const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, AgnosticCoupo
     return profileData.me.activeCart;
   },
   addItem: async (context: Context, { currentCart, product, quantity, customQuery }) => {
-    const loadedCart = await getCurrentCart(context, currentCart);
+    const cartDetails = await getCurrentCartDetails(context, currentCart);
 
-    const { data } = await context.$ct.api.addToCart(loadedCart, product, quantity, customQuery);
+    const { data } = await context.$ct.api.addToCart(cartDetails, product, quantity, customQuery);
     return data.cart;
   },
   removeItem: async (context: Context, { currentCart, product, customQuery }) => {
-    const loadedCart = await getCurrentCart(context, currentCart);
+    const cartDetails = await getCurrentCartDetails(context, currentCart);
 
-    const { data } = await context.$ct.api.removeFromCart(loadedCart, product, customQuery);
+    const { data } = await context.$ct.api.removeFromCart(cartDetails, product, customQuery);
     return data.cart;
   },
   updateItemQty: async (context: Context, { currentCart, product, quantity, customQuery }) => {
-    const loadedCart = await getCurrentCart(context, currentCart);
+    const cartDetails = await getCurrentCartDetails(context, currentCart);
 
-    const { data } = await context.$ct.api.updateCartQuantity(loadedCart, { ...product, quantity }, customQuery);
+    const { data } = await context.$ct.api.updateCartQuantity(cartDetails, { ...product, quantity }, customQuery);
     return data.cart;
   },
   clear: async (context: Context, { currentCart }) => {
     return currentCart;
   },
   applyCoupon: async (context: Context, { currentCart, couponCode, customQuery }) => {
-    const loadedCart = await getCurrentCart(context, currentCart);
+    const cartDetails = await getCurrentCartDetails(context, currentCart);
 
-    const { data } = await context.$ct.api.applyCartCoupon(loadedCart, couponCode, customQuery);
+    const { data } = await context.$ct.api.applyCartCoupon(cartDetails, couponCode, customQuery);
     return { updatedCart: data.cart, updatedCoupon: couponCode };
   },
   removeCoupon: async (context: Context, { currentCart, coupon, customQuery }) => {
-    const loadedCart = await getCurrentCart(context, currentCart);
+    const cartDetails = await getCurrentCartDetails(context, currentCart);
 
-    const { data } = await context.$ct.api.removeCartCoupon(loadedCart, { id: coupon.id, typeId: 'discount-code' }, customQuery);
+    const { data } = await context.$ct.api.removeCartCoupon(cartDetails, { id: coupon.id, typeId: 'discount-code' }, customQuery);
     return { updatedCart: data.cart };
   },
   isInCart: (context: Context, { currentCart, product }) => {
@@ -67,4 +66,4 @@ const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, AgnosticCoupo
   }
 };
 
-export default useCartFactory<Cart, LineItem, ProductVariant, AgnosticCoupon>(params);
+export default useCartFactory<CartDetails, LineItem, ProductVariant, AgnosticCoupon>(params);

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -3,7 +3,7 @@ import { ProductVariant, LineItem } from './../types/GraphQL';
 import { CartDetails } from '@vue-storefront/commercetools-api';
 import { AgnosticCoupon, useCartFactory, UseCartFactoryParams, Context } from '@vue-storefront/core';
 
-const getBasketItemByProduct = ({ currentCart, product }) => {
+const getCartItemByProduct = ({ currentCart, product }) => {
   return currentCart.lineItems.find((item) => item.productId === product._id);
 };
 
@@ -62,7 +62,7 @@ const params: UseCartFactoryParams<CartDetails, LineItem, ProductVariant, Agnost
     return { updatedCart: data.cart };
   },
   isInCart: (context: Context, { currentCart, product }) => {
-    return Boolean(currentCart && getBasketItemByProduct({ currentCart, product }));
+    return Boolean(currentCart && getCartItemByProduct({ currentCart, product }));
   }
 };
 

--- a/packages/core/docs/commercetools/changelog/5836.js
+++ b/packages/core/docs/commercetools/changelog/5836.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Reduce payload size for cart methods',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5836',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};


### PR DESCRIPTION
### Short Description of the PR
When cart methods are called, we include the whole cart object in the payload sent to the `api-client` (Server Middleware). This becomes an issue when the cart contains multiple items and uses custom queries to add more properties to it, resulting in an `HTTP 413 Payload Too Large` error.
This PR fixes it by only sending data that is needed - cart `id` and `version`.

### Pull Request Checklist
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)
