### PR TITLE
Patch: filter attributes without options (eg: category_ids)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.13.1] - UNRELEASED
-
-### Fixed
-
-- Solves the use of attributes without options as filters in the category pages.
-
 ## [1.13.0] - UNRELEASED
 
 ### Added
@@ -45,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: the code to remove the page key from the query before applying a filter - @ymaheshwari1 ([VSF Capybara #561](https://github.com/vuestorefront/vsf-capybara/issues/561))
 - Changing regex responsible for UnicodeAlpha validation and added unit tests - @lukaszjedrasik ([#5340](https://github.com/vuestorefront/vue-storefront/issues/5340))
 - Bugfix for problems with global state in SSR during concurrently requests from different stores - @cewald (#5639)
+- Solves the use of attributes without options as filters in the category pages.
 
 ### Changed / Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - UNRELEASED
+
+### Fixed
+
+- Solves the use of attributes without options as filters in the category pages.
+
 ## [1.13.0] - UNRELEASED
 
 ### Added

--- a/core/modules/catalog/helpers/optionLabel.ts
+++ b/core/modules/catalog/helpers/optionLabel.ts
@@ -20,9 +20,15 @@ export function optionLabel (state, { attributeKey, searchBy = 'code', optionId 
 
   let attr = state['list_by_' + searchBy][attributeKey]
   if (attr) {
-    let opt = attr.options.find((op) => toString(op.value) === toString(optionId))
+    let opt = {
+      'label': null
+    }
 
-    if (opt) {
+    if (attr.options) {
+      opt = attr.options.find((op) => toString(op.value) === toString(optionId))
+    }
+
+    if (opt && opt.label !== null) {
       if (!state.labels[attributeKey]) {
         state.labels[attributeKey] = {}
       }

--- a/core/modules/catalog/helpers/optionLabel.ts
+++ b/core/modules/catalog/helpers/optionLabel.ts
@@ -19,16 +19,16 @@ export function optionLabel (state, { attributeKey, searchBy = 'code', optionId 
   }
 
   let attr = state['list_by_' + searchBy][attributeKey]
-  if (attr) {
+  if (attr && Array.isArray(attr.options)) {
     let opt = {
       'label': null
     }
 
     if (attr.options) {
-      opt = attr.options.find((op) => toString(op.value) === toString(optionId))
+      opt = attr.options.find(option => toString(option.value) === toString(optionId))
     }
 
-    if (opt && opt.label !== null) {
+    if (opt && opt.label) {
       if (!state.labels[attributeKey]) {
         state.labels[attributeKey] = {}
       }

--- a/core/modules/catalog/helpers/optionLabel.ts
+++ b/core/modules/catalog/helpers/optionLabel.ts
@@ -20,20 +20,14 @@ export function optionLabel (state, { attributeKey, searchBy = 'code', optionId 
 
   let attr = state['list_by_' + searchBy][attributeKey]
   if (attr && Array.isArray(attr.options)) {
-    let opt = {
-      'label': null
-    }
-
-    if (attr.options) {
-      opt = attr.options.find(option => toString(option.value) === toString(optionId))
-    }
+    let opt = attr.options.find(option => toString(option.value) === toString(optionId));
 
     if (opt && opt.label) {
       if (!state.labels[attributeKey]) {
         state.labels[attributeKey] = {}
       }
       state.labels[attributeKey][optionId] = opt.label
-      return opt ? opt.label : optionId
+      return opt.label
     } else {
       return optionId
     }


### PR DESCRIPTION
### Related Issues
https://forum.vuestorefront.io/t/category-ids-breaks-on-options-key/2194

### Short Description of the PR
This patch permits to use attributes without options to filter the catalog.

### Pull Request Checklist
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date. --> No updates necessary in this case
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [X] Default Theme
- [X] Capybara Theme


