### PR TITLE
fix: Order history pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect load of default address in checkout - @lukaszjedrasik ([#4682](https://github.com/vuestorefront/vue-storefront/issues/4682))
 - Error with unknown theme/index.js alias - @Fifciuu (https://github.com/vuestorefront/vue-storefront/pull/5813)
 - ESLint warnings caused by the double import - @lukaszjedrasik
+- Fix Order History Pagination - @AishwaryShrivastav / @lukaszjedrasik ([#4599](https://github.com/vuestorefront/vue-storefront/issues/4599))
+
 ### Changed / Improved
 
 - Moved hardcoded fields from omitSelectedVariantFields.ts to config (#4679)

--- a/core/modules/order/components/UserOrdersHistory.ts
+++ b/core/modules/order/components/UserOrdersHistory.ts
@@ -25,10 +25,7 @@ export default {
   },
   methods: {
     onBottomScroll () {
-      const totalCount = this.$store.state.user.orders_history.total_count ? this.$store.state.user.orders_history.total_count : 0;
-      const isLastPage = this.pagination.current > Math.ceil(totalCount / this.pagination.perPage);
-      if (!isLastPage) {
-        ++this.pagination.current;
+        this.pagination.current++;
         this.$store.dispatch('user/appendOrdersHistory', { pageSize: this.pagination.perPage, currentPage: this.pagination.current });
       }
     }

--- a/core/modules/order/components/UserOrdersHistory.ts
+++ b/core/modules/order/components/UserOrdersHistory.ts
@@ -25,8 +25,14 @@ export default {
   },
   methods: {
     onBottomScroll () {
+      const totalCount = this.$store.state.user.orders_history.total_count ? this.$store.state.user.orders_history.total_count : 0;
+      const isLastPage = this.pagination.current > Math.ceil(totalCount / this.pagination.perPage);
+      if (!isLastPage) {
         this.pagination.current++;
-        this.$store.dispatch('user/appendOrdersHistory', { pageSize: this.pagination.perPage, currentPage: this.pagination.current });
+        this.$store.dispatch('user/appendOrdersHistory', {
+          pageSize: this.pagination.perPage,
+          currentPage: this.pagination.current
+        });
       }
     }
   }

--- a/core/modules/order/components/UserOrdersHistory.ts
+++ b/core/modules/order/components/UserOrdersHistory.ts
@@ -18,14 +18,19 @@ export default {
     ordersHistory () {
       let items = this.getOrdersHistory
       if (this.lazyLoadOrdersOnScroll) {
-        items = items.slice(0, (this.pagination.perPage + 1) * this.pagination.current)
+        items = items.slice(0, this.pagination.perPage * this.pagination.current)
       }
       return items
     }
   },
   methods: {
     onBottomScroll () {
-      ++this.pagination.current
+      const totalCount = this.$store.state.user.orders_history.total_count ? this.$store.state.user.orders_history.total_count : 0;
+      const isLastPage = this.pagination.current > Math.ceil(totalCount / this.pagination.perPage);
+      if (!isLastPage) {
+        ++this.pagination.current;
+        this.$store.dispatch('user/appendOrdersHistory', { pageSize: this.pagination.perPage, currentPage: this.pagination.current });
+      }
     }
   }
 }

--- a/core/modules/user/test/unit/store/actions.spec.ts
+++ b/core/modules/user/test/unit/store/actions.spec.ts
@@ -456,6 +456,31 @@ describe('User actions', () => {
     })
   });
 
+  describe('appendOrdersHistory action', () => {
+    it('should append order to orders history', async () => {
+      const responseOb = {
+        result: data.ordersHistory,
+        code: 200
+      };
+      (UserService.getOrdersHistory as jest.Mock).mockImplementation(async () => responseOb);
+      const contextMock = {
+        commit: jest.fn(),
+        getters: {
+          getOrdersHistory: responseOb.result
+        }
+      };
+      const pageSize = data.pageSize;
+      const currentPage = data.currentPage;
+
+      await (userActions as any).appendOrdersHistory(contextMock, {
+        pageSize,
+        currentPage
+      })
+
+      expect(contextMock.commit).toBeCalledWith(types.USER_ORDERS_HISTORY_LOADED, responseOb.result);
+    })
+  })
+
   describe('refreshOrderHistory action', () => {
     it('should refresh orders history', async () => {
       const responseOb = {

--- a/core/modules/user/test/unit/store/actions.spec.ts
+++ b/core/modules/user/test/unit/store/actions.spec.ts
@@ -472,12 +472,14 @@ describe('User actions', () => {
       const pageSize = data.pageSize;
       const currentPage = data.currentPage;
 
-      await (userActions as any).appendOrdersHistory(contextMock, {
+      const result = await (userActions as any).appendOrdersHistory(contextMock, {
         pageSize,
         currentPage
       })
 
       expect(contextMock.commit).toBeCalledWith(types.USER_ORDERS_HISTORY_LOADED, responseOb.result);
+      expect(EventBus.$emit).toBeCalledWith('user-after-loaded-orders', result);
+      expect(result).toBe(responseOb.result)
     })
   })
 

--- a/core/modules/user/test/unit/store/actions.spec.ts
+++ b/core/modules/user/test/unit/store/actions.spec.ts
@@ -482,7 +482,7 @@ describe('User actions', () => {
       expect(result).toBe(responseOb.result)
     })
 
-    it('returns unique orders', async () => {
+    it('returns orders with unique increment_id', async () => {
       const oldOrders = [
         { name: 'a', increment_id: 0 },
         { name: 'b', increment_id: 1 }

--- a/core/modules/user/test/unit/store/actions.spec.ts
+++ b/core/modules/user/test/unit/store/actions.spec.ts
@@ -481,6 +481,46 @@ describe('User actions', () => {
       expect(EventBus.$emit).toBeCalledWith('user-after-loaded-orders', result);
       expect(result).toBe(responseOb.result)
     })
+
+    it('returns unique orders', async () => {
+      const oldOrders = [
+        { name: 'a', increment_id: 0 },
+        { name: 'b', increment_id: 1 }
+      ]
+      const orders = {
+        items: [
+          { name: 'a', increment_id: 0 },
+          { name: 'c', increment_id: 2 }
+        ]
+      }
+      const responseOb = {
+        result: orders,
+        code: 200
+      };
+      const contextMock = {
+        commit: jest.fn(),
+        getters: {
+          getOrdersHistory: oldOrders
+        }
+      };
+      const pageSize = data.pageSize;
+      const currentPage = data.currentPage;
+
+      (UserService.getOrdersHistory as jest.Mock).mockImplementation(async () => responseOb);
+      const result = await (userActions as any).appendOrdersHistory(contextMock, {
+        pageSize,
+        currentPage
+      })
+      const expectedResult = {
+        items: [
+          { name: 'a', increment_id: 0 },
+          { name: 'b', increment_id: 1 },
+          { name: 'c', increment_id: 2 }
+        ]
+      }
+
+      expect(result).toEqual(expectedResult);
+    })
   })
 
   describe('refreshOrderHistory action', () => {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4599 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed pagination support (user can see more than 20 orders)
- Added new user action `appendOrdersHistory` + unit test
- Showed 10 orders at the start instead 11

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [x] Default Theme
- [x] Capybara Theme
- [x] I have written test cases for my code
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


