### PR TITLE
Allow more control over how Apollo links can be overwritten

### DIFF
--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/index.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/index.ts
@@ -102,7 +102,26 @@ const createCommerceToolsConnection = (settings: Config): any => {
     delay: () => 0
   });
 
-  const apolloLink = ApolloLink.from([onErrorLink, errorRetry, authLinkBefore, authLinkAfter.concat(httpLink)]);
+  let links: ApolloLink[] = [
+    onErrorLink,
+    errorRetry,
+    authLinkBefore,
+    authLinkAfter.concat(httpLink)
+  ];
+
+  if (settings.overrideApolloLinks) {
+    links = settings.overrideApolloLinks({
+      sdkAuth,
+      tokenProvider,
+      httpLink,
+      onErrorLink,
+      authLinkBefore,
+      authLinkAfter,
+      errorRetry
+    });
+  }
+
+  const apolloLink = ApolloLink.from(links);
 
   return {
     apolloLink,

--- a/packages/commercetools/api-client/src/types/setup.ts
+++ b/packages/commercetools/api-client/src/types/setup.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { ApolloLink } from 'apollo-link';
 import SdkAuth, { TokenProvider } from '@commercetools/sdk-auth';
 import ApolloClient, { ApolloClientOptions } from 'apollo-client';
 
@@ -63,6 +64,16 @@ export interface CustomerCredentials {
   password: string;
 }
 
+export interface OverrideApolloLinksParameters {
+  sdkAuth: SdkAuth;
+  tokenProvider: TokenProvider;
+  httpLink: ApolloLink;
+  onErrorLink: ApolloLink;
+  authLinkBefore: ApolloLink;
+  authLinkAfter: ApolloLink;
+  errorRetry: ApolloLink;
+}
+
 export interface Config<T = any> {
   client?: ApolloClient<T>;
   api: ApiConfig;
@@ -79,4 +90,5 @@ export interface Config<T = any> {
   auth?: Auth;
   forceToken?: boolean;
   handleIsTokenUserSession: (token: Token) => boolean;
+  overrideApolloLinks: (config: OverrideApolloLinksParameters) => ApolloLink[];
 }

--- a/packages/core/docs/commercetools/changelog/5867.js
+++ b/packages/core/docs/commercetools/changelog/5867.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Allow more control over how Apollo links can be overwritten',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5867',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};


### PR DESCRIPTION
### Short Description of the PR
Allow more control over how Apollo links can be overwritten

### Pull Request Checklist
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)