### PR TITLE
Replace Slack links to Discord in docs

### DIFF
--- a/packages/core/docs/.vuepress/components/PersonTile.vue
+++ b/packages/core/docs/.vuepress/components/PersonTile.vue
@@ -3,13 +3,13 @@
     <img :src="photo" />
     <div><b> {{ name }} </b></div>
     <div class="gap">{{ company }} </div>
-    <div><b><a href="https://slack.vuestorefront.io">Slack:</a></b> @{{ slack }} </div>
+    <div><b><a href="https://discord.vuestorefront.io">Discord:</a></b> {{ discord }} </div>
   </div>
 </template>
 
 <script>
 export default {
-  props: ['name', 'company', 'slack', 'photo']
+  props: ['name', 'company', 'discord', 'photo']
 }
 </script>
 

--- a/packages/core/docs/commercetools/maintainers.md
+++ b/packages/core/docs/commercetools/maintainers.md
@@ -5,7 +5,7 @@ The Commercetools integration is developed and maintained by **Vue Storefront co
 
 ## Support
 
-In case of any questions, reach out to the maintainers in the `#commercetools` channel on our [Discord](discord.vuestorefront.io) server. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
+In case of any questions, reach out to the maintainers in the `#commercetools` channel on our [Discord](https://discord.vuestorefront.io) server. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
 
 <PersonTile 
   photo="https://avatars3.githubusercontent.com/u/7943292?s=460&u=74f1c2a48fdbac23962aa3b1f7346bc0c9e55309&v=4"

--- a/packages/core/docs/commercetools/maintainers.md
+++ b/packages/core/docs/commercetools/maintainers.md
@@ -5,11 +5,11 @@ The Commercetools integration is developed and maintained by **Vue Storefront co
 
 ## Support
 
-In case of any questions don't hesitate reaching out to the maintainers on [Slack](slack.vuestorefront.io) and visiting `#commercetools` channel. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
+In case of any questions, reach out to the maintainers in the `#commercetools` channel on our [Discord](discord.vuestorefront.io) server. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
 
 <PersonTile 
   photo="https://avatars3.githubusercontent.com/u/7943292?s=460&u=74f1c2a48fdbac23962aa3b1f7346bc0c9e55309&v=4"
   name="Patryk Andrzejewski"
   company="Vue Storefront"
-  slack="andrzejewsky"
+  discord="andrzejewsky#9834"
 />

--- a/packages/core/docs/enterprise/feature-list.md
+++ b/packages/core/docs/enterprise/feature-list.md
@@ -367,7 +367,7 @@ All Vue Storefront Cloud config options are available via API
 
 **14. SLA & Support**
 
-The Storefront Cloud team will guarantee 99,8% SLA for the infrastructure and Vue Storefront base app (modifications and custom integrations created by merchant/agency are excluded). Our clients can use our dedicated Slack support channel to contact the team and check the tickets’ statuses.
+The Storefront Cloud team will guarantee 99,8% SLA for the infrastructure and Vue Storefront base app (modifications and custom integrations created by merchant/agency are excluded). Our clients can use our dedicated Slack support channel to contact the team and check the ticket statuses.
 
 **15. API Integratios with 3rd party services OOTB**
 

--- a/packages/core/docs/integrate/cache-driver.md
+++ b/packages/core/docs/integrate/cache-driver.md
@@ -1,7 +1,7 @@
 # Integrating cache driver
 
 ::: warning Want to build an integration?
-If you want to integrate with Vue Storefront, please **contact the core team on our [slack](https://slack.vuestorefront.io)** first. We are eager to help you with building it and ensuring its high quality! Building the integration together with the core team is the best way to keep its quality high and make it officially recommended once it's done.
+If you want to integrate with Vue Storefront, please **contact the core team on our [Discord](https://discord.vuestorefront.io) server** first. We are eager to help you with building it and ensuring its high quality! Building the integration with the help of the core team is the best way to keep its quality high and making it officially recommended once completed.
 :::
 
 ## Introduction

--- a/packages/core/docs/integrate/cms.md
+++ b/packages/core/docs/integrate/cms.md
@@ -1,7 +1,7 @@
 # Integrating CMS
 
 ::: warning Want to build an integration?
-If you want to integrate with Vue Storefront, please **contact the core team on our [slack](https://slack.vuestorefront.io)** first. We are eager to help you with building it and ensuring its high quality! Building the integration together with the core team is the best way to keep its quality high and make it officially recommended once it's done.
+If you want to integrate with Vue Storefront, please **contact the core team on our [Discord](https://discord.vuestorefront.io) server** first. We are eager to help you with building it and ensuring its high quality! Building the integration with the help of the core team is the best way to keep its quality high and making it officially recommended once completed.
 :::
 
 ## What is needed

--- a/packages/core/docs/integrate/integration-guide.md
+++ b/packages/core/docs/integrate/integration-guide.md
@@ -1,7 +1,7 @@
 # Integration guide
 
 ::: warning Want to build an integration?
-If you want to integrate with Vue Storefront, please **contact the core team on our [slack](https://slack.vuestorefront.io)** first. We are eager to help you with building it and ensuring its high quality! Building the integration together with the core team is the best way to keep its quality high and make it officially recommended once it's done.
+If you want to integrate with Vue Storefront, please **contact the core team on our [Discord](https://discord.vuestorefront.io) server** first. We are eager to help you with building it and ensuring its high quality! Building the integration with the help of the core team is the best way to keep its quality high and making it officially recommended once completed.
 :::
 
 ## Introduction

--- a/packages/core/docs/shopify/maintainers.md
+++ b/packages/core/docs/shopify/maintainers.md
@@ -6,17 +6,17 @@ The Shopify integration is developed and maintained by the core partner **Aureat
 
 ## Support
 
-In case of any questions don't hesitate reaching out to the maintainers on [Slack](slack.vuestorefront.io) and visiting `#shopify` channel. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
+In case of any questions, reach out to the maintainers in the `#shopify` channel on our [Discord](discord.vuestorefront.io) server. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
 
 <PersonTile 
-  photo="https://avatars2.githubusercontent.com/u/783102?s=460&u=38994305c6b6ce2be5519544251d6875263dfb1a&v=4"
-  name="Yogesh Suhagiya"
+  photo="https://avatars.githubusercontent.com/u/1814821?v=4"
+  name="Piyush Lathiya"
   company="Aureate Labs"
-  slack="yogeshsuhagiya"
+  discord="Piyush Lathiya#1282"
 />
 <PersonTile 
   photo="https://user-images.githubusercontent.com/65275444/114853628-9bbddf80-9e01-11eb-90f2-500d6e645b8f.png"
   name="Viral Rana"
   company="Aureate Labs"
-  slack="viralrana"
+  discord="viralr07#1995"
 />

--- a/packages/core/docs/shopify/maintainers.md
+++ b/packages/core/docs/shopify/maintainers.md
@@ -6,7 +6,7 @@ The Shopify integration is developed and maintained by the core partner **Aureat
 
 ## Support
 
-In case of any questions, reach out to the maintainers in the `#shopify` channel on our [Discord](discord.vuestorefront.io) server. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
+In case of any questions, reach out to the maintainers in the `#shopify` channel on our [Discord](https://discord.vuestorefront.io) server. You can also [hire the core team](https://www.vuestorefront.io/support) to support you in delivering your project.
 
 <PersonTile 
   photo="https://avatars.githubusercontent.com/u/1814821?v=4"


### PR DESCRIPTION
### Short Description of the PR
Replace Slack links to Discord in docs
