### PR TITLE
Add build:middleware to build:core script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:docs": "cd packages/core/docs && yarn build",
     "dev:docs": "cd packages/core/docs && yarn dev",
-    "build:core": "yarn build:middleware && cd packages/core/core && yarn build",
+    "build:core": "cd packages/core/core && yarn build && cd - && yarn build:middleware",
     "build:middleware": "cd packages/core/middleware && yarn build",
     "build:spr:api-client": "cd packages/spryker/api-client && yarn build",
     "build:spr:composables": "cd packages/spryker/composables && yarn build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:docs": "cd packages/core/docs && yarn build",
     "dev:docs": "cd packages/core/docs && yarn dev",
-    "build:core": "cd packages/core/core && yarn build",
+    "build:core": "yarn build:middleware && cd packages/core/core && yarn build",
     "build:middleware": "cd packages/core/middleware && yarn build",
     "build:spr:api-client": "cd packages/spryker/api-client && yarn build",
     "build:spr:composables": "cd packages/spryker/composables && yarn build",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5882 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Adds `build:middleware` command to `build:core` script

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


