### PR TITLE
Fix reactivity of "error" objects in composables

### DIFF
--- a/packages/core/core/src/factories/useCartFactory.ts
+++ b/packages/core/core/src/factories/useCartFactory.ts
@@ -1,6 +1,6 @@
 import { CustomQuery, UseCart, Context, FactoryParams, UseCartErrors } from '../types';
 import { Ref, computed } from '@vue/composition-api';
-import { sharedRef, Logger, configureFactoryParams } from '../utils';
+import { sharedRef, Logger, configureFactoryParams, createErrorHandler } from '../utils';
 
 export interface UseCartFactoryParams<CART, CART_ITEM, PRODUCT, COUPON> extends FactoryParams {
   load: (context: Context, params: { customQuery?: any }) => Promise<CART>;
@@ -34,7 +34,7 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
     const loading: Ref<boolean> = sharedRef(false, 'useCart-loading');
     const cart: Ref<CART> = sharedRef(null, 'useCart-cart');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseCartErrors> = sharedRef({
+    const errorHandler = createErrorHandler<UseCartErrors>({
       addItem: null,
       removeItem: null,
       updateItemQty: null,
@@ -60,10 +60,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           quantity,
           customQuery
         });
-        error.value.addItem = null;
+        errorHandler.clear('addItem');
         cart.value = updatedCart;
       } catch (err) {
-        error.value.addItem = err;
+        errorHandler.update('addItem', err);
         Logger.error('useCart/addItem', err);
       } finally {
         loading.value = false;
@@ -80,10 +80,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           product,
           customQuery
         });
-        error.value.removeItem = null;
+        errorHandler.clear('removeItem');
         cart.value = updatedCart;
       } catch (err) {
-        error.value.removeItem = err;
+        errorHandler.update('removeItem', err);
         Logger.error('useCart/removeItem', err);
       } finally {
         loading.value = false;
@@ -102,10 +102,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
             quantity,
             customQuery
           });
-          error.value.updateItemQty = null;
+          errorHandler.clear('updateItemQty');
           cart.value = updatedCart;
         } catch (err) {
-          error.value.updateItemQty = err;
+          errorHandler.update('updateItemQty', err);
           Logger.error('useCart/updateItemQty', err);
         } finally {
           loading.value = false;
@@ -123,16 +123,16 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           * temporary issue related with cpapi plugin
           */
         loading.value = false;
-        error.value.load = null;
+        errorHandler.clear('load');
         cart.value = { ...cart.value };
         return;
       }
       try {
         loading.value = true;
         cart.value = await _factoryParams.load({ customQuery });
-        error.value.load = null;
+        errorHandler.clear('load');
       } catch (err) {
-        error.value.load = err;
+        errorHandler.update('load', err);
         Logger.error('useCart/load', err);
       } finally {
         loading.value = false;
@@ -145,10 +145,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
       try {
         loading.value = true;
         const updatedCart = await _factoryParams.clear({ currentCart: cart.value });
-        error.value.clear = null;
+        errorHandler.clear('clear');
         cart.value = updatedCart;
       } catch (err) {
-        error.value.clear = err;
+        errorHandler.update('clear', err);
         Logger.error('useCart/clear', err);
       } finally {
         loading.value = false;
@@ -172,10 +172,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           couponCode,
           customQuery
         });
-        error.value.applyCoupon = null;
+        errorHandler.clear('applyCoupon');
         cart.value = updatedCart;
       } catch (err) {
-        error.value.applyCoupon = err;
+        errorHandler.update('applyCoupon', err);
         Logger.error('useCart/applyCoupon', err);
       } finally {
         loading.value = false;
@@ -192,11 +192,11 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           coupon,
           customQuery
         });
-        error.value.removeCoupon = null;
+        errorHandler.clear('removeCoupon');
         cart.value = updatedCart;
         loading.value = false;
       } catch (err) {
-        error.value.removeCoupon = err;
+        errorHandler.update('removeCoupon', err);
         Logger.error('useCart/removeCoupon', err);
       } finally {
         loading.value = false;
@@ -215,7 +215,7 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
       applyCoupon,
       removeCoupon,
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: errorHandler.getAll()
     };
   };
 };

--- a/packages/core/core/src/factories/useShippingFactory.ts
+++ b/packages/core/core/src/factories/useShippingFactory.ts
@@ -1,6 +1,6 @@
 import { UseShipping, Context, FactoryParams, UseShippingErrors, CustomQuery } from '../types';
 import { Ref, computed } from '@vue/composition-api';
-import { sharedRef, Logger, configureFactoryParams } from '../utils';
+import { sharedRef, Logger, configureFactoryParams, createErrorHandler } from '../utils';
 
 export interface UseShippingParams<SHIPPING, SHIPPING_PARAMS> extends FactoryParams {
   load: (context: Context, params: { customQuery?: CustomQuery }) => Promise<SHIPPING>;
@@ -14,7 +14,7 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
     const loading: Ref<boolean> = sharedRef(false, 'useShipping-loading');
     const shipping: Ref<SHIPPING> = sharedRef(null, 'useShipping-shipping');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseShippingErrors> = sharedRef({
+    const errorHandler = createErrorHandler<UseShippingErrors>({
       load: null,
       save: null
     }, 'useShipping-error');
@@ -25,10 +25,10 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
       try {
         loading.value = true;
         const shippingInfo = await _factoryParams.load({ customQuery });
-        error.value.load = null;
+        errorHandler.clear('load');
         shipping.value = shippingInfo;
       } catch (err) {
-        error.value.load = err;
+        errorHandler.update('load', err);
         Logger.error('useShipping/load', err);
       } finally {
         loading.value = false;
@@ -41,10 +41,10 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
       try {
         loading.value = true;
         const shippingInfo = await _factoryParams.save(saveParams);
-        error.value.save = null;
+        errorHandler.clear('save');
         shipping.value = shippingInfo;
       } catch (err) {
-        error.value.save = err;
+        errorHandler.update('save', err);
         Logger.error('useShipping/save', err);
       } finally {
         loading.value = false;
@@ -54,7 +54,7 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
     return {
       shipping: computed(() => shipping.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: errorHandler.getAll(),
       load,
       save
     };

--- a/packages/core/core/src/factories/useUserBillingFactory.ts
+++ b/packages/core/core/src/factories/useUserBillingFactory.ts
@@ -1,6 +1,6 @@
 import { Ref, unref, computed } from '@vue/composition-api';
 import { UseUserBilling, Context, FactoryParams, UseUserBillingErrors, CustomQuery } from '../types';
-import { sharedRef, Logger, configureFactoryParams } from '../utils';
+import { sharedRef, Logger, configureFactoryParams, createErrorHandler } from '../utils';
 
 export interface UseUserBillingFactoryParams<USER_BILLING, USER_BILLING_ITEM> extends FactoryParams{
   addAddress: (
@@ -46,7 +46,7 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
     const loading: Ref<boolean> = sharedRef(false, 'useUserBilling-loading');
     const billing: Ref<USER_BILLING> = sharedRef({}, 'useUserBilling-billing');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseUserBillingErrors> = sharedRef({
+    const errorHandler = createErrorHandler<UseUserBillingErrors>({
       addAddress: null,
       deleteAddress: null,
       updateAddress: null,
@@ -66,9 +66,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.addAddress = null;
+        errorHandler.clear('addAddress');
       } catch (err) {
-        error.value.addAddress = err;
+        errorHandler.update('addAddress', err);
         Logger.error('useUserBilling/addAddress', err);
       } finally {
         loading.value = false;
@@ -85,9 +85,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.deleteAddress = null;
+        errorHandler.clear('deleteAddress');
       } catch (err) {
-        error.value.deleteAddress = err;
+        errorHandler.update('deleteAddress', err);
         Logger.error('useUserBilling/deleteAddress', err);
       } finally {
         loading.value = false;
@@ -104,9 +104,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.updateAddress = null;
+        errorHandler.clear('updateAddress');
       } catch (err) {
-        error.value.updateAddress = err;
+        errorHandler.update('updateAddress', err);
         Logger.error('useUserBilling/updateAddress', err);
       } finally {
         loading.value = false;
@@ -121,9 +121,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
         billing.value = await _factoryParams.load({
           billing: readonlyBilling
         });
-        error.value.load = null;
+        errorHandler.clear('load');
       } catch (err) {
-        error.value.load = err;
+        errorHandler.update('load', err);
         Logger.error('useUserBilling/load', err);
       } finally {
         loading.value = false;
@@ -140,9 +140,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.setDefaultAddress = null;
+        errorHandler.clear('setDefaultAddress');
       } catch (err) {
-        error.value.setDefaultAddress = err;
+        errorHandler.update('setDefaultAddress', err);
         Logger.error('useUserBilling/setDefaultAddress', err);
       } finally {
         loading.value = false;
@@ -152,7 +152,7 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
     return {
       billing: computed(() => billing.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: errorHandler.getAll(),
       addAddress,
       deleteAddress,
       updateAddress,

--- a/packages/core/core/src/factories/useUserShippingFactory.ts
+++ b/packages/core/core/src/factories/useUserShippingFactory.ts
@@ -1,6 +1,6 @@
 import { Ref, unref, computed } from '@vue/composition-api';
 import { UseUserShipping, Context, FactoryParams, UseUserShippingErrors, CustomQuery } from '../types';
-import { sharedRef, Logger, mask, configureFactoryParams } from '../utils';
+import { sharedRef, Logger, mask, configureFactoryParams, createErrorHandler } from '../utils';
 
 export interface UseUserShippingFactoryParams<USER_SHIPPING, USER_SHIPPING_ITEM> extends FactoryParams {
   addAddress: (
@@ -47,7 +47,7 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
     const shipping: Ref<USER_SHIPPING> = sharedRef({}, 'useUserShipping-shipping');
     const _factoryParams = configureFactoryParams(factoryParams);
     const readonlyShipping: Readonly<USER_SHIPPING> = unref(shipping);
-    const error: Ref<UseUserShippingErrors> = sharedRef({
+    const errorHandler = createErrorHandler<UseUserShippingErrors>({
       addAddress: null,
       deleteAddress: null,
       updateAddress: null,
@@ -65,9 +65,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.addAddress = null;
+        errorHandler.clear('addAddress');
       } catch (err) {
-        error.value.addAddress = err;
+        errorHandler.update('addAddress', err);
         Logger.error('useUserShipping/addAddress', err);
       } finally {
         loading.value = false;
@@ -84,9 +84,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.deleteAddress = null;
+        errorHandler.clear('deleteAddress');
       } catch (err) {
-        error.value.deleteAddress = err;
+        errorHandler.update('deleteAddress', err);
         Logger.error('useUserShipping/deleteAddress', err);
       } finally {
         loading.value = false;
@@ -103,9 +103,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.updateAddress = null;
+        errorHandler.clear('updateAddress');
       } catch (err) {
-        error.value.updateAddress = err;
+        errorHandler.update('updateAddress', err);
         Logger.error('useUserShipping/updateAddress', err);
       } finally {
         loading.value = false;
@@ -120,9 +120,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
         shipping.value = await _factoryParams.load({
           shipping: readonlyShipping
         });
-        error.value.load = null;
+        errorHandler.clear('load');
       } catch (err) {
-        error.value.load = err;
+        errorHandler.update('load', err);
         Logger.error('useUserShipping/load', err);
       } finally {
         loading.value = false;
@@ -139,9 +139,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.setDefaultAddress = null;
+        errorHandler.clear('setDefaultAddress');
       } catch (err) {
-        error.value.setDefaultAddress = err;
+        errorHandler.update('setDefaultAddress', err);
         Logger.error('useUserShipping/setDefaultAddress', err);
       } finally {
         loading.value = false;
@@ -151,7 +151,7 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
     return {
       shipping: computed(() => shipping.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: errorHandler.getAll(),
       addAddress,
       deleteAddress,
       updateAddress,

--- a/packages/core/core/src/utils/error/index.ts
+++ b/packages/core/core/src/utils/error/index.ts
@@ -1,0 +1,63 @@
+import { computed, ComputedRef, Ref } from '@vue/composition-api';
+import { sharedRef } from '../shared';
+import { ComputedProperty } from '../../types';
+
+interface ErrorHandler<E> {
+  get(name: string): ComputedRef<Error>;
+  getAll(): ComputedProperty<E>;
+  update(name: string, value: any): void;
+  clear(name: string): void;
+  clearAll(): void;
+}
+
+function createErrorHandler<E>(values: E, name: string): ErrorHandler<E> {
+  const entries: Ref<E> = sharedRef({}, name);
+
+  /**
+   * Get single error
+   */
+  const get = (name) => computed(() => entries.value[name]);
+
+  /**
+   * Get all errors
+   */
+  const getAll = () => computed(() => entries.value);
+
+  /**
+   * Update single error
+   */
+  const update = (name, value: Error) => {
+    entries.value = { ...entries.value, [name]: value };
+  };
+
+  /**
+   * Clear single error
+   */
+  const clear = (name) => update(name, null);
+
+  /**
+   * Clear all errors
+   */
+  const clearAll = () => {
+    entries.value = Object
+      .keys(values)
+      .reduce((carry: E, item: string) => ({
+        ...carry,
+        [item]: null
+      }), {} as E);
+  };
+
+  clearAll();
+
+  return {
+    get,
+    getAll,
+    update,
+    clear,
+    clearAll
+  };
+}
+
+export {
+  createErrorHandler
+};

--- a/packages/core/core/src/utils/index.ts
+++ b/packages/core/core/src/utils/index.ts
@@ -1,25 +1,10 @@
 /* istanbul ignore file */
 
-import { onSSR, vsfRef, configureSSR } from './ssr';
-import { sharedRef } from './shared';
-import wrap from './wrap';
-import { Logger, registerLogger } from './logger';
-import mask from './logger/mask';
-import { useVSFContext, configureContext, generateContext, configureFactoryParams } from './context';
-import { integrationPlugin } from './nuxt';
-
-export {
-  wrap,
-  onSSR,
-  vsfRef,
-  configureSSR,
-  sharedRef,
-  Logger,
-  registerLogger,
-  mask,
-  configureContext,
-  useVSFContext,
-  configureFactoryParams,
-  generateContext,
-  integrationPlugin
-};
+export { useVSFContext, configureContext, generateContext, configureFactoryParams } from './context';
+export { createErrorHandler } from './error';
+export { Logger, registerLogger } from './logger';
+export { mask } from './logger/mask';
+export { integrationPlugin } from './nuxt';
+export { sharedRef } from './shared';
+export { onSSR, vsfRef, configureSSR } from './ssr';
+export { wrap } from './wrap';

--- a/packages/core/core/src/utils/logger/mask.ts
+++ b/packages/core/core/src/utils/logger/mask.ts
@@ -8,7 +8,7 @@ const maskAny = (el: any) => {
   return '***';
 };
 
-const mask = (el: any): any => {
+export const mask = (el: any): any => {
   if (typeof el === 'object' && !Array.isArray(el)) {
     return Object.keys(el).reduce((prev, key) => ({
       ...prev,
@@ -18,5 +18,3 @@ const mask = (el: any): any => {
 
   return maskAny(el);
 };
-
-export default mask;

--- a/packages/core/core/src/utils/wrap/index.ts
+++ b/packages/core/core/src/utils/wrap/index.ts
@@ -1,5 +1,5 @@
 import { isRef, ref, Ref, UnwrapRef } from '@vue/composition-api';
 
-export default function wrap<T>(element: Ref<UnwrapRef<T>> | T): Ref<UnwrapRef<T>> {
+export function wrap<T>(element: Ref<UnwrapRef<T>> | T): Ref<UnwrapRef<T>> {
   return isRef(element) ? element : ref<T>(element as T);
 }

--- a/packages/core/docs/changelog/5904.js
+++ b/packages/core/docs/changelog/5904.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fix reactivity of "error" objects in composables',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5904/',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};

--- a/packages/core/docs/guide/composables.md
+++ b/packages/core/docs/guide/composables.md
@@ -377,7 +377,7 @@ import { useUiNotification } from '~/composables';
 const { cart, error } = useCart();
 const { send } = useUiNotification();
 
-watch(() => ({...error.value}), (error, prevError) => {
+watch(() => error.value, (error, prevError) => {
   if (error.addItem && error.addItem !== prevError.addItem)
     send({ type: 'danger', message: error.addItem.message });
   if (


### PR DESCRIPTION
### Short Description of the PR
This PR fixes the reactivity of "error" objects. Currently, when an error occurs we only update the key inside of the "error" object. This doesn't work well with Vue.js devtools and the `watch` method.

To see the updated state in devtools, it's required to select another component and select the initial one again.

`watch` only works in one specific case and `watchEffect` doesn't work at all:

```javascript
    watch(() => ({ ...error.value }), value=> console.log(value)); // Works
    watch(() => error.value, value=> console.log(value));  // Doesn't work
    watchEffect(() => console.log(error.value)); // Doesn't work
```

When this PR is merged, devtools and all 3 watchers will work as expected

### Pull Request Checklist
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)
