### PR TITLE
support for async hooks

### DIFF
--- a/packages/core/core/src/factories/apiClientFactory/index.ts
+++ b/packages/core/core/src/factories/apiClientFactory/index.ts
@@ -51,7 +51,7 @@ const apiClientFactory = <ALL_SETTINGS extends ApiClientConfig, ALL_FUNCTIONS>(f
 
     settings.config = lifecycles.reduce(
       handleHook('afterCreate', callWithProp('configuration')),
-      config
+      settings.config
     );
 
     const before = (params) => lifecycles

--- a/yarn.lock
+++ b/yarn.lock
@@ -7481,7 +7481,7 @@ err-code@^1.0.0:
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
   integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
 
-errno@^0.1.3:
+errno@^0.1.3, errno@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz#8bb3e9c7d463be4976ff888f76b4809ebc2e811f"
   integrity sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==


### PR DESCRIPTION
### Related Issues
https://vsf.atlassian.net/browse/OS-64

### Short Description of the PR
Hooks in the middleware are not async, which can be an issue when someone would like to trigger some async action there.
Added support for async call for `beforeCreate`, `afterCreate`, `beforeCall` and `afterCall` hooks.