### PR TITLE
Add fail-fast flag to regression workflow

### DIFF
--- a/.github/workflows/run-e2e-regression.yml
+++ b/.github/workflows/run-e2e-regression.yml
@@ -7,6 +7,7 @@ jobs:
     name: Run E2E Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package: ["ct", "bp"]
     steps:

--- a/packages/boilerplate/theme/tests/e2e/integration/e2e-place-order.spec.ts
+++ b/packages/boilerplate/theme/tests/e2e/integration/e2e-place-order.spec.ts
@@ -9,7 +9,7 @@ before(() => {
 });
 
 context('Order placement', () => {
-  it(['e2e', 'happypath'], 'Should successfully place an order', () => {
+  it(['happypath', 'regression'], 'Should successfully place an order', () => {
     const data = cy.fixtures.data;
     page.home.visit();
     page.home.header.categories.first().click();

--- a/packages/boilerplate/theme/tests/e2e/integration/e2e-place-order.spec.ts
+++ b/packages/boilerplate/theme/tests/e2e/integration/e2e-place-order.spec.ts
@@ -1,16 +1,16 @@
 import page from '../pages/factory';
 
-before(() => {
-  cy.fixture('test-data/e2e-place-order').then((fixture) => {
-    cy.fixtures = {
-      data: fixture
-    };
-  });
-});
-
 context('Order placement', () => {
-  it(['happypath', 'regression'], 'Should successfully place an order', () => {
-    const data = cy.fixtures.data;
+  beforeEach(function () {
+    cy.fixture('test-data/e2e-place-order').then((fixture) => {
+      this.fixtures = {
+        data: fixture
+      };
+    });
+  });
+
+  it(['happypath', 'regression'], 'Should successfully place an order', function () {
+    const data = this.fixtures.data;
     page.home.visit();
     page.home.header.categories.first().click();
     page.category.products.first().click();


### PR DESCRIPTION
 * Change tags in bp hp e2e test

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5911 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Adds fail-fast flag set to false to e2e regression workflow. Changes tags in boilerplate e2e happy path test.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


