### PR TITLE
support for async hooks

### DIFF
--- a/packages/core/core/__tests__/factories/apiClientFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/apiClientFactory.spec.ts
@@ -17,7 +17,8 @@ describe('[CORE - factories] apiClientFactory', () => {
 
     const { createApiClient } = apiClientFactory<any, any>(params as any) as any;
 
-    expect(createApiClient({}).settings).toEqual({});
+    const { settings } = createApiClient({});
+    expect(settings).toEqual({});
   });
 
   it('Should merge with default settings when setup is called', () => {
@@ -71,7 +72,7 @@ describe('[CORE - factories] apiClientFactory', () => {
     expect(afterCreate).toHaveBeenCalled();
   });
 
-  it('applyContextToApi adds context as first argument to api functions', () => {
+  it('applyContextToApi adds context as first argument to api functions', async () => {
     const api = {
       firstFunc: jest.fn(),
       secondFunc: jest.fn(),
@@ -83,9 +84,9 @@ describe('[CORE - factories] apiClientFactory', () => {
 
     const apiWithContext: any = applyContextToApi(api, context);
 
-    apiWithContext.firstFunc();
-    apiWithContext.secondFunc('TEST');
-    apiWithContext.thirdFunc('A', 'FEW', 'ARGS');
+    await apiWithContext.firstFunc();
+    await apiWithContext.secondFunc('TEST');
+    await apiWithContext.thirdFunc('A', 'FEW', 'ARGS');
 
     expect(api.firstFunc).toHaveBeenCalledWith(
       expect.objectContaining({ extendQuery: expect.any(Function) })

--- a/packages/core/core/src/factories/apiClientFactory/context.ts
+++ b/packages/core/core/src/factories/apiClientFactory/context.ts
@@ -1,8 +1,8 @@
 import { ApiClientMethod } from './../../types';
 
 interface ApplyingContextHooks {
-  before: ({ callName, args }) => any[];
-  after: ({ callName, args, response }) => any;
+  before: ({ callName, args }) => Promise<any[]>;
+  after: ({ callName, args, response }) => Promise<any>;
 }
 
 const nopBefore = ({ args }) => args;
@@ -40,10 +40,10 @@ const applyContextToApi = (
       ...prev,
       [callName]: async (...args) => {
         const extendQuery = createExtendQuery(context);
-        const transformedArgs = hooks.before({ callName, args });
+        const transformedArgs = await hooks.before({ callName, args });
         const apiClientContext = { ...context, extendQuery };
         const response = await fn(apiClientContext, ...transformedArgs);
-        const transformedResponse = hooks.after({ callName, args, response });
+        const transformedResponse = await hooks.after({ callName, args, response });
 
         return transformedResponse;
       }

--- a/packages/core/core/src/factories/apiClientFactory/index.ts
+++ b/packages/core/core/src/factories/apiClientFactory/index.ts
@@ -3,47 +3,73 @@ import {
   ApiClientConfig,
   ApiInstance,
   ApiClientFactory,
-  ApiClientExtension
+  ApiClientExtension,
+  ApiClientExtensionHooks
 } from './../../types';
 import { Logger } from './../../utils';
 import { applyContextToApi } from './context';
 
-const isFn = (x) => typeof x === 'function';
+type Fn<A extends any [] = any [], B = any> = (...xs: A) => B;
+type HooksNames = keyof ApiClientExtensionHooks;
+
+const isFn = (x): x is Fn => typeof x === 'function';
+
+const callWithProp = (prop: string, rest: any = {}) => (result: any, hook: any) =>
+  isFn(hook)
+    ? hook({...rest, [prop]: result})
+    : result;
+
+const callThenWithProp = (prop: string, rest: any = {}) => (result: any, hook: any) =>
+  isFn(hook)
+    ? result.then(result => hook({...rest, [prop]: result}))
+    : result;
+
+const handleHook = (hookName: HooksNames, call: Fn) => (result: any, next: ApiClientExtensionHooks) =>
+  call(result, next[hookName]);
 
 const apiClientFactory = <ALL_SETTINGS extends ApiClientConfig, ALL_FUNCTIONS>(factoryParams: ApiClientFactoryParams<ALL_SETTINGS, ALL_FUNCTIONS>): ApiClientFactory => {
   function createApiClient (config: any, customApi: any = {}): ApiInstance {
     const rawExtensions: ApiClientExtension[] = this?.middleware?.extensions || [];
+
     const lifecycles = Object.values(rawExtensions)
       .filter(ext => isFn(ext.hooks))
       .map(({ hooks }) => hooks(this?.middleware?.req, this?.middleware?.res));
+
     const extendedApis = Object.keys(rawExtensions)
       .reduce((prev, curr) => ({ ...prev, ...rawExtensions[curr].extendApiMethods }), customApi);
 
-    const _config = lifecycles
-      .filter(ext => isFn(ext.beforeCreate))
-      .reduce((prev, curr) => curr.beforeCreate({ configuration: prev }), config);
+    const _config = lifecycles.reduce(
+      handleHook('beforeCreate', callWithProp('configuration')),
+      config
+    );
 
-    const settings = factoryParams.onCreate ? factoryParams.onCreate(_config) : { config, client: config.client };
+    const settings = factoryParams.onCreate
+      ? factoryParams.onCreate(_config)
+      : { config, client: config.client };
 
     Logger.debug('apiClientFactory.create', settings);
 
-    settings.config = lifecycles
-      .filter(ext => isFn(ext.afterCreate))
-      .reduce((prev, curr) => curr.afterCreate({ configuration: prev }), settings.config);
+    settings.config = lifecycles.reduce(
+      handleHook('afterCreate', callWithProp('configuration')),
+      settings.config
+    );
 
-    const extensionHooks = {
-      before: (params) => lifecycles
-        .filter(e => isFn(e.beforeCall))
-        .reduce((args, e) => e.beforeCall({ ...params, configuration: settings.config, args}), params.args),
-      after: (params) => lifecycles
-        .filter(e => isFn(e.afterCall))
-        .reduce((response, e) => e.afterCall({ ...params, configuration: settings.config, response }), params.response)
-    };
+    const before = (params) => lifecycles
+      .reduce(
+        handleHook('beforeCall', callThenWithProp('args', {...params, configuration: settings.config})),
+        Promise.resolve(params.args)
+      );
+
+    const after = (params) => lifecycles
+      .reduce(
+        handleHook('afterCall', callThenWithProp('response', {...params, configuration: settings.config})),
+        Promise.resolve(params.response)
+      );
 
     const api = applyContextToApi(
       { ...factoryParams.api, ...extendedApis },
       { ...settings, ...this?.middleware || {} },
-      extensionHooks
+      { before, after }
     );
 
     return {

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -654,8 +654,8 @@ export interface AfterCallParams<C> extends CallHookParams<C> {
 export interface ApiClientExtensionHooks<C = any> {
   beforeCreate?: (params: HookParams<C>) => C;
   afterCreate?: (params: HookParams<C>) => C;
-  beforeCall?: (params: BeforeCallParams<C>) => BeforeCallArgs;
-  afterCall?: (params: AfterCallParams<C>) => AfterCallArgs;
+  beforeCall?: (params: BeforeCallParams<C>) => Promise<BeforeCallArgs>;
+  afterCall?: (params: AfterCallParams<C>) => Promise<AfterCallArgs>;
 }
 
 export type CustomQueryFn<T = any> = (query: any, variables: T) => {

--- a/packages/core/docs/changelog/5914.js
+++ b/packages/core/docs/changelog/5914.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'createApiClient support for async hooks',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5914',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'vn-vlad',
+  linkToGitHubAccount: 'https://github.com/vn-vlad'
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6196,9 +6196,9 @@ core-js@^2.5.3, core-js@^2.6.5:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.0.1, core-js@^3.6.4, core-js@^3.6.5:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.1.tgz#e683963978b6806dcc6c0a4a8bd4ab0bdaf3f21a"
-  integrity sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
+  integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
### Related Issues
https://vsf.atlassian.net/browse/OS-64

### Short Description of the PR
Hooks in the middleware are not async, which can be an issue when someone would like to trigger some async action there.
Added support for async call for `beforeCreate`, `afterCreate`, `beforeCall` and `afterCall` hooks.