### PR TITLE
Fix reactivity of "error" objects in composables

### DIFF
--- a/packages/core/core/src/factories/useBillingFactory.ts
+++ b/packages/core/core/src/factories/useBillingFactory.ts
@@ -1,5 +1,5 @@
 import { UseBilling, Context, FactoryParams, UseBillingErrors, CustomQuery } from '../types';
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
 export interface UseBillingParams<BILLING, BILLING_PARAMS> extends FactoryParams {
@@ -14,10 +14,10 @@ export const useBillingFactory = <BILLING, BILLING_PARAMS>(
     const loading: Ref<boolean> = sharedRef(false, 'useBilling-loading');
     const billing: Ref<BILLING> = sharedRef(null, 'useBilling-billing');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseBillingErrors> = sharedRef({
+    const error: UnwrapRef<UseBillingErrors> = reactive({
       load: null,
       save: null
-    }, 'useBilling-error');
+    });
 
     const load = async ({ customQuery = null } = {}) => {
       Logger.debug('useBilling.load');
@@ -25,10 +25,10 @@ export const useBillingFactory = <BILLING, BILLING_PARAMS>(
       try {
         loading.value = true;
         const billingInfo = await _factoryParams.load({ customQuery });
-        error.value.load = null;
+        error.load = null;
         billing.value = billingInfo;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useBilling/load', err);
       } finally {
         loading.value = false;
@@ -41,10 +41,10 @@ export const useBillingFactory = <BILLING, BILLING_PARAMS>(
       try {
         loading.value = true;
         const billingInfo = await _factoryParams.save(saveParams);
-        error.value.save = null;
+        error.save = null;
         billing.value = billingInfo;
       } catch (err) {
-        error.value.save = err;
+        error.save = err;
         Logger.error('useBilling/save', err);
       } finally {
         loading.value = false;
@@ -54,7 +54,7 @@ export const useBillingFactory = <BILLING, BILLING_PARAMS>(
     return {
       billing: computed(() => billing.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: computed(() => error),
       load,
       save
     };

--- a/packages/core/core/src/factories/useCartFactory.ts
+++ b/packages/core/core/src/factories/useCartFactory.ts
@@ -1,5 +1,5 @@
 import { CustomQuery, UseCart, Context, FactoryParams, UseCartErrors } from '../types';
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
 export interface UseCartFactoryParams<CART, CART_ITEM, PRODUCT, COUPON> extends FactoryParams {
@@ -34,7 +34,7 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
     const loading: Ref<boolean> = sharedRef(false, 'useCart-loading');
     const cart: Ref<CART> = sharedRef(null, 'useCart-cart');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseCartErrors> = sharedRef({
+    const error: UnwrapRef<UseCartErrors> = reactive({
       addItem: null,
       removeItem: null,
       updateItemQty: null,
@@ -42,7 +42,7 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
       clear: null,
       applyCoupon: null,
       removeCoupon: null
-    }, 'useCart-error');
+    });
 
     const setCart = (newCart: CART) => {
       cart.value = newCart;
@@ -60,10 +60,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           quantity,
           customQuery
         });
-        error.value.addItem = null;
+        error.addItem = null;
         cart.value = updatedCart;
       } catch (err) {
-        error.value.addItem = err;
+        error.addItem = err;
         Logger.error('useCart/addItem', err);
       } finally {
         loading.value = false;
@@ -80,10 +80,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           product,
           customQuery
         });
-        error.value.removeItem = null;
+        error.removeItem = null;
         cart.value = updatedCart;
       } catch (err) {
-        error.value.removeItem = err;
+        error.removeItem = err;
         Logger.error('useCart/removeItem', err);
       } finally {
         loading.value = false;
@@ -102,10 +102,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
             quantity,
             customQuery
           });
-          error.value.updateItemQty = null;
+          error.updateItemQty = null;
           cart.value = updatedCart;
         } catch (err) {
-          error.value.updateItemQty = err;
+          error.updateItemQty = err;
           Logger.error('useCart/updateItemQty', err);
         } finally {
           loading.value = false;
@@ -123,16 +123,16 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           * temporary issue related with cpapi plugin
           */
         loading.value = false;
-        error.value.load = null;
+        error.load = null;
         cart.value = { ...cart.value };
         return;
       }
       try {
         loading.value = true;
         cart.value = await _factoryParams.load({ customQuery });
-        error.value.load = null;
+        error.load = null;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useCart/load', err);
       } finally {
         loading.value = false;
@@ -145,10 +145,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
       try {
         loading.value = true;
         const updatedCart = await _factoryParams.clear({ currentCart: cart.value });
-        error.value.clear = null;
+        error.clear = null;
         cart.value = updatedCart;
       } catch (err) {
-        error.value.clear = err;
+        error.clear = err;
         Logger.error('useCart/clear', err);
       } finally {
         loading.value = false;
@@ -172,10 +172,10 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           couponCode,
           customQuery
         });
-        error.value.applyCoupon = null;
+        error.applyCoupon = null;
         cart.value = updatedCart;
       } catch (err) {
-        error.value.applyCoupon = err;
+        error.applyCoupon = err;
         Logger.error('useCart/applyCoupon', err);
       } finally {
         loading.value = false;
@@ -192,11 +192,11 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
           coupon,
           customQuery
         });
-        error.value.removeCoupon = null;
+        error.removeCoupon = null;
         cart.value = updatedCart;
         loading.value = false;
       } catch (err) {
-        error.value.removeCoupon = err;
+        error.removeCoupon = err;
         Logger.error('useCart/removeCoupon', err);
       } finally {
         loading.value = false;
@@ -215,7 +215,7 @@ export const useCartFactory = <CART, CART_ITEM, PRODUCT, COUPON>(
       applyCoupon,
       removeCoupon,
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 };

--- a/packages/core/core/src/factories/useCategoryFactory.ts
+++ b/packages/core/core/src/factories/useCategoryFactory.ts
@@ -1,5 +1,5 @@
 import { CustomQuery, UseCategory, Context, FactoryParams, UseCategoryErrors } from '../types';
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
 export interface UseCategoryFactoryParams<CATEGORY, CATEGORY_SEARCH_PARAMS> extends FactoryParams {
@@ -13,9 +13,9 @@ export function useCategoryFactory<CATEGORY, CATEGORY_SEARCH_PARAMS>(
     const categories: Ref<CATEGORY[]> = sharedRef([], `useCategory-categories-${id}`);
     const loading = sharedRef(false, `useCategory-loading-${id}`);
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseCategoryErrors> = sharedRef({
+    const error: UnwrapRef<UseCategoryErrors> = reactive({
       search: null
-    }, `useCategory-error-${id}`);
+    });
 
     const search = async (searchParams) => {
       Logger.debug(`useCategory/${id}/search`, searchParams);
@@ -23,9 +23,9 @@ export function useCategoryFactory<CATEGORY, CATEGORY_SEARCH_PARAMS>(
       try {
         loading.value = true;
         categories.value = await _factoryParams.categorySearch(searchParams);
-        error.value.search = null;
+        error.search = null;
       } catch (err) {
-        error.value.search = err;
+        error.search = err;
         Logger.error(`useCategory/${id}/search`, err);
       } finally {
         loading.value = false;
@@ -36,7 +36,7 @@ export function useCategoryFactory<CATEGORY, CATEGORY_SEARCH_PARAMS>(
       search,
       loading: computed(() => loading.value),
       categories: computed(() => categories.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 }

--- a/packages/core/core/src/factories/useContentFactory.ts
+++ b/packages/core/core/src/factories/useContentFactory.ts
@@ -1,4 +1,4 @@
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { RenderComponent, UseContent, Context, FactoryParams, UseContentErrors } from '../types';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 import { PropOptions, VNode } from 'vue';
@@ -13,9 +13,9 @@ export function useContentFactory<CONTENT, CONTENT_SEARCH_PARAMS>(
   return function useContent(id: string): UseContent<CONTENT, CONTENT_SEARCH_PARAMS> {
     const content: Ref<CONTENT> = sharedRef([], `useContent-content-${id}`);
     const loading: Ref<boolean> = sharedRef(false, `useContent-loading-${id}`);
-    const error: Ref<UseContentErrors> = sharedRef({
+    const error: UnwrapRef<UseContentErrors> = reactive({
       search: null
-    }, `useContent-error-${id}`);
+    });
     const _factoryParams = configureFactoryParams(factoryParams);
 
     const search = async(params: CONTENT_SEARCH_PARAMS): Promise<void> => {
@@ -24,9 +24,9 @@ export function useContentFactory<CONTENT, CONTENT_SEARCH_PARAMS>(
       try {
         loading.value = true;
         content.value = await _factoryParams.search(params);
-        error.value.search = null;
+        error.search = null;
       } catch (err) {
-        error.value.search = err;
+        error.search = err;
         Logger.error(`useContent/${id}/search`, err);
       } finally {
         loading.value = false;
@@ -37,7 +37,7 @@ export function useContentFactory<CONTENT, CONTENT_SEARCH_PARAMS>(
       search,
       content: computed(() => content.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 }

--- a/packages/core/core/src/factories/useFacetFactory.ts
+++ b/packages/core/core/src/factories/useFacetFactory.ts
@@ -1,5 +1,5 @@
-import { Ref, computed } from '@vue/composition-api';
-import { sharedRef, vsfRef, Logger, configureFactoryParams } from '../utils';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
+import { vsfRef, Logger, configureFactoryParams } from '../utils';
 import { UseFacet, FacetSearchResult, AgnosticFacetSearchParams, Context, FactoryParams, UseFacetErrors } from '../types';
 
 interface UseFacetFactoryParams<SEARCH_DATA> extends FactoryParams {
@@ -13,9 +13,9 @@ const useFacetFactory = <SEARCH_DATA>(factoryParams: UseFacetFactoryParams<SEARC
     const loading: Ref<boolean> = vsfRef(false, `${ssrKey}-loading`);
     const result: Ref<FacetSearchResult<SEARCH_DATA>> = vsfRef({ data: null, input: null }, `${ssrKey}-facets`);
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseFacetErrors> = sharedRef({
+    const error: UnwrapRef<UseFacetErrors> = reactive({
       search: null
-    }, `useFacet-error-${id}`);
+    });
 
     const search = async (params?: AgnosticFacetSearchParams) => {
       Logger.debug(`useFacet/${ssrKey}/search`, params);
@@ -24,9 +24,9 @@ const useFacetFactory = <SEARCH_DATA>(factoryParams: UseFacetFactoryParams<SEARC
       try {
         loading.value = true;
         result.value.data = await _factoryParams.search(result.value);
-        error.value.search = null;
+        error.search = null;
       } catch (err) {
-        error.value.search = err;
+        error.search = err;
         Logger.error(`useFacet/${ssrKey}/search`, err);
       } finally {
         loading.value = false;
@@ -36,7 +36,7 @@ const useFacetFactory = <SEARCH_DATA>(factoryParams: UseFacetFactoryParams<SEARC
     return {
       result: computed(() => result.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: computed(() => error),
       search
     };
   };

--- a/packages/core/core/src/factories/useMakeOrderFactory.ts
+++ b/packages/core/core/src/factories/useMakeOrderFactory.ts
@@ -1,4 +1,4 @@
-import { computed, Ref } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { CustomQuery, Context, FactoryParams, UseMakeOrder, UseMakeOrderErrors } from '../types';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
@@ -12,9 +12,9 @@ export const useMakeOrderFactory = <ORDER>(
   return function useMakeOrder(): UseMakeOrder<ORDER> {
     const order: Ref<ORDER> = sharedRef(null, 'useMakeOrder-order');
     const loading: Ref<boolean> = sharedRef(false, 'useMakeOrder-loading');
-    const error: Ref<UseMakeOrderErrors> = sharedRef({
+    const error: UnwrapRef<UseMakeOrderErrors> = reactive({
       make: null
-    }, 'useMakeOrder-error');
+    });
     const _factoryParams = configureFactoryParams(factoryParams);
 
     const make = async (params = { customQuery: null }) => {
@@ -23,10 +23,10 @@ export const useMakeOrderFactory = <ORDER>(
       try {
         loading.value = true;
         const createdOrder = await _factoryParams.make(params);
-        error.value.make = null;
+        error.make = null;
         order.value = createdOrder;
       } catch (err) {
-        error.value.make = err;
+        error.make = err;
         Logger.error('useMakeOrder.make', err);
       } finally {
         loading.value = false;
@@ -37,7 +37,7 @@ export const useMakeOrderFactory = <ORDER>(
       order,
       make,
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 };

--- a/packages/core/core/src/factories/useProductFactory.ts
+++ b/packages/core/core/src/factories/useProductFactory.ts
@@ -1,5 +1,5 @@
 import { CustomQuery, ProductsSearchParams, UseProduct, Context, FactoryParams, UseProductErrors } from '../types';
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 export interface UseProductFactoryParams<PRODUCTS, PRODUCT_SEARCH_PARAMS extends ProductsSearchParams> extends FactoryParams {
   productsSearch: (context: Context, params: PRODUCT_SEARCH_PARAMS & { customQuery?: CustomQuery }) => Promise<PRODUCTS>;
@@ -12,9 +12,9 @@ export function useProductFactory<PRODUCTS, PRODUCT_SEARCH_PARAMS>(
     const products: Ref<PRODUCTS> = sharedRef([], `useProduct-products-${id}`);
     const loading = sharedRef(false, `useProduct-loading-${id}`);
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseProductErrors> = sharedRef({
+    const error: UnwrapRef<UseProductErrors> = reactive({
       search: null
-    }, `useProduct-error-${id}`);
+    });
 
     const search = async (searchParams) => {
       Logger.debug(`useProduct/${id}/search`, searchParams);
@@ -22,9 +22,9 @@ export function useProductFactory<PRODUCTS, PRODUCT_SEARCH_PARAMS>(
       try {
         loading.value = true;
         products.value = await _factoryParams.productsSearch(searchParams);
-        error.value.search = null;
+        error.search = null;
       } catch (err) {
-        error.value.search = err;
+        error.search = err;
         Logger.error(`useProduct/${id}/search`, err);
       } finally {
         loading.value = false;
@@ -35,7 +35,7 @@ export function useProductFactory<PRODUCTS, PRODUCT_SEARCH_PARAMS>(
       search,
       products: computed(() => products.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 }

--- a/packages/core/core/src/factories/useReviewFactory.ts
+++ b/packages/core/core/src/factories/useReviewFactory.ts
@@ -1,4 +1,4 @@
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { CustomQuery, UseReview, Context, FactoryParams, UseReviewErrors } from '../types';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
@@ -13,10 +13,10 @@ export function useReviewFactory<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAM
   return function useReview(id: string): UseReview<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAMS> {
     const reviews: Ref<REVIEW> = sharedRef([], `useReviews-reviews-${id}`);
     const loading: Ref<boolean> = sharedRef(false, `useReviews-loading-${id}`);
-    const error: Ref<UseReviewErrors> = sharedRef({
+    const error: UnwrapRef<UseReviewErrors> = reactive({
       search: null,
       addReview: null
-    }, `useReviews-error-${id}`);
+    });
     const _factoryParams = configureFactoryParams(factoryParams);
 
     const search = async (searchParams): Promise<void> => {
@@ -25,9 +25,9 @@ export function useReviewFactory<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAM
       try {
         loading.value = true;
         reviews.value = await _factoryParams.searchReviews(searchParams);
-        error.value.search = null;
+        error.search = null;
       } catch (err) {
-        error.value.search = err;
+        error.search = err;
         Logger.error(`useReview/${id}/search`, err);
       } finally {
         loading.value = false;
@@ -40,9 +40,9 @@ export function useReviewFactory<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAM
       try {
         loading.value = true;
         reviews.value = await _factoryParams.addReview(params);
-        error.value.addReview = null;
+        error.addReview = null;
       } catch (err) {
-        error.value.addReview = err;
+        error.addReview = err;
         Logger.error(`useReview/${id}/addReview`, err);
       } finally {
         loading.value = false;
@@ -54,7 +54,7 @@ export function useReviewFactory<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAM
       addReview,
       reviews: computed(() => reviews.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 }

--- a/packages/core/core/src/factories/useShippingFactory.ts
+++ b/packages/core/core/src/factories/useShippingFactory.ts
@@ -1,5 +1,5 @@
 import { UseShipping, Context, FactoryParams, UseShippingErrors, CustomQuery } from '../types';
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
 export interface UseShippingParams<SHIPPING, SHIPPING_PARAMS> extends FactoryParams {
@@ -14,10 +14,10 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
     const loading: Ref<boolean> = sharedRef(false, 'useShipping-loading');
     const shipping: Ref<SHIPPING> = sharedRef(null, 'useShipping-shipping');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseShippingErrors> = sharedRef({
+    const error: UnwrapRef<UseShippingErrors> = reactive({
       load: null,
       save: null
-    }, 'useShipping-error');
+    });
 
     const load = async ({ customQuery = null } = {}) => {
       Logger.debug('useShipping.load');
@@ -25,10 +25,10 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
       try {
         loading.value = true;
         const shippingInfo = await _factoryParams.load({ customQuery });
-        error.value.load = null;
+        error.load = null;
         shipping.value = shippingInfo;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useShipping/load', err);
       } finally {
         loading.value = false;
@@ -41,10 +41,10 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
       try {
         loading.value = true;
         const shippingInfo = await _factoryParams.save(saveParams);
-        error.value.save = null;
+        error.save = null;
         shipping.value = shippingInfo;
       } catch (err) {
-        error.value.save = err;
+        error.save = err;
         Logger.error('useShipping/save', err);
       } finally {
         loading.value = false;
@@ -54,7 +54,7 @@ export const useShippingFactory = <SHIPPING, SHIPPING_PARAMS>(
     return {
       shipping: computed(() => shipping.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: computed(() => error),
       load,
       save
     };

--- a/packages/core/core/src/factories/useShippingProviderFactory.ts
+++ b/packages/core/core/src/factories/useShippingProviderFactory.ts
@@ -1,5 +1,5 @@
 import { UseShippingProvider, Context, FactoryParams, UseShippingProviderErrors, CustomQuery } from '../types';
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
 export interface UseShippingProviderParams<STATE, SHIPPING_METHOD> extends FactoryParams {
@@ -14,10 +14,10 @@ export const useShippingProviderFactory = <STATE, SHIPPING_METHOD>(
     const loading: Ref<boolean> = sharedRef(false, 'useShippingProvider-loading');
     const state: Ref<STATE> = sharedRef(null, 'useShippingProvider-response');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseShippingProviderErrors> = sharedRef({
+    const error: UnwrapRef<UseShippingProviderErrors> = reactive({
       load: null,
       save: null
-    }, 'useShippingProvider-error');
+    });
 
     const setState = (newState: STATE) => {
       state.value = newState;
@@ -30,9 +30,9 @@ export const useShippingProviderFactory = <STATE, SHIPPING_METHOD>(
       try {
         loading.value = true;
         state.value = await _factoryParams.save({ shippingMethod, customQuery, state });
-        error.value.save = null;
+        error.save = null;
       } catch (err) {
-        error.value.save = err;
+        error.save = err;
         Logger.error('useShippingProvider/save', err);
       } finally {
         loading.value = false;
@@ -45,9 +45,9 @@ export const useShippingProviderFactory = <STATE, SHIPPING_METHOD>(
       try {
         loading.value = true;
         state.value = await _factoryParams.load({ customQuery, state });
-        error.value.load = null;
+        error.load = null;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useShippingProvider/load', err);
       } finally {
         loading.value = false;
@@ -57,7 +57,7 @@ export const useShippingProviderFactory = <STATE, SHIPPING_METHOD>(
     return {
       state,
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: computed(() => error),
       load,
       save,
       setState

--- a/packages/core/core/src/factories/useUserBillingFactory.ts
+++ b/packages/core/core/src/factories/useUserBillingFactory.ts
@@ -1,4 +1,4 @@
-import { Ref, unref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, unref, computed, reactive } from '@vue/composition-api';
 import { UseUserBilling, Context, FactoryParams, UseUserBillingErrors, CustomQuery } from '../types';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
@@ -46,13 +46,13 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
     const loading: Ref<boolean> = sharedRef(false, 'useUserBilling-loading');
     const billing: Ref<USER_BILLING> = sharedRef({}, 'useUserBilling-billing');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseUserBillingErrors> = sharedRef({
+    const error: UnwrapRef<UseUserBillingErrors> = reactive({
       addAddress: null,
       deleteAddress: null,
       updateAddress: null,
       load: null,
       setDefaultAddress: null
-    }, 'useUserBilling-error');
+    });
 
     const readonlyBilling: Readonly<USER_BILLING> = unref(billing);
 
@@ -66,9 +66,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.addAddress = null;
+        error.addAddress = null;
       } catch (err) {
-        error.value.addAddress = err;
+        error.addAddress = err;
         Logger.error('useUserBilling/addAddress', err);
       } finally {
         loading.value = false;
@@ -85,9 +85,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.deleteAddress = null;
+        error.deleteAddress = null;
       } catch (err) {
-        error.value.deleteAddress = err;
+        error.deleteAddress = err;
         Logger.error('useUserBilling/deleteAddress', err);
       } finally {
         loading.value = false;
@@ -104,9 +104,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.updateAddress = null;
+        error.updateAddress = null;
       } catch (err) {
-        error.value.updateAddress = err;
+        error.updateAddress = err;
         Logger.error('useUserBilling/updateAddress', err);
       } finally {
         loading.value = false;
@@ -121,9 +121,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
         billing.value = await _factoryParams.load({
           billing: readonlyBilling
         });
-        error.value.load = null;
+        error.load = null;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useUserBilling/load', err);
       } finally {
         loading.value = false;
@@ -140,9 +140,9 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
           billing: readonlyBilling,
           customQuery
         });
-        error.value.setDefaultAddress = null;
+        error.setDefaultAddress = null;
       } catch (err) {
-        error.value.setDefaultAddress = err;
+        error.setDefaultAddress = err;
         Logger.error('useUserBilling/setDefaultAddress', err);
       } finally {
         loading.value = false;
@@ -152,7 +152,7 @@ export const useUserBillingFactory = <USER_BILLING, USER_BILLING_ITEM>(
     return {
       billing: computed(() => billing.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: computed(() => error),
       addAddress,
       deleteAddress,
       updateAddress,

--- a/packages/core/core/src/factories/useUserFactory.ts
+++ b/packages/core/core/src/factories/useUserFactory.ts
@@ -1,4 +1,4 @@
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, computed, UnwrapRef, reactive } from '@vue/composition-api';
 import { UseUser, Context, FactoryParams, UseUserErrors } from '../types';
 import { sharedRef, Logger, mask, configureFactoryParams } from '../utils';
 
@@ -28,7 +28,7 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
     const loading: Ref<boolean> = sharedRef(false, 'useUser-loading');
     const isAuthenticated = computed(() => Boolean(user.value));
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseUserErrors> = sharedRef(errorsFactory(), 'useUser-error');
+    const error: UnwrapRef<UseUserErrors> = reactive(errorsFactory());
 
     const setUser = (newUser: USER) => {
       user.value = newUser;
@@ -36,7 +36,12 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
     };
 
     const resetErrorValue = () => {
-      error.value = errorsFactory();
+      error.updateUser = null;
+      error.register = null;
+      error.login = null;
+      error.logout = null;
+      error.changePassword = null;
+      error.load = null;
     };
 
     const updateUser = async ({ user: providedUser }) => {
@@ -46,9 +51,9 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       try {
         loading.value = true;
         user.value = await _factoryParams.updateUser({currentUser: user.value, updatedUserData: providedUser});
-        error.value.updateUser = null;
+        error.updateUser = null;
       } catch (err) {
-        error.value.updateUser = err;
+        error.updateUser = err;
         Logger.error('useUser/updateUser', err);
       } finally {
         loading.value = false;
@@ -62,9 +67,9 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       try {
         loading.value = true;
         user.value = await _factoryParams.register(providedUser);
-        error.value.register = null;
+        error.register = null;
       } catch (err) {
-        error.value.register = err;
+        error.register = err;
         Logger.error('useUser/register', err);
       } finally {
         loading.value = false;
@@ -78,9 +83,9 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       try {
         loading.value = true;
         user.value = await _factoryParams.logIn(providedUser);
-        error.value.login = null;
+        error.login = null;
       } catch (err) {
-        error.value.login = err;
+        error.login = err;
         Logger.error('useUser/login', err);
       } finally {
         loading.value = false;
@@ -93,10 +98,10 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
 
       try {
         await _factoryParams.logOut();
-        error.value.logout = null;
+        error.logout = null;
         user.value = null;
       } catch (err) {
-        error.value.logout = err;
+        error.logout = err;
         Logger.error('useUser/logout', err);
       }
     };
@@ -112,9 +117,9 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
           currentPassword: params.current,
           newPassword: params.new
         });
-        error.value.changePassword = null;
+        error.changePassword = null;
       } catch (err) {
-        error.value.changePassword = err;
+        error.changePassword = err;
         Logger.error('useUser/changePassword', err);
       } finally {
         loading.value = false;
@@ -128,9 +133,9 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       try {
         loading.value = true;
         user.value = await _factoryParams.load();
-        error.value.load = null;
+        error.load = null;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useUser/load', err);
       } finally {
         loading.value = false;
@@ -148,7 +153,7 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       changePassword,
       load,
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 };

--- a/packages/core/core/src/factories/useUserOrderFactory.ts
+++ b/packages/core/core/src/factories/useUserOrderFactory.ts
@@ -1,4 +1,4 @@
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { CustomQuery, UseUserOrder, Context, FactoryParams, UseUserOrderErrors } from '../types';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
@@ -11,7 +11,9 @@ export function useUserOrderFactory<ORDERS, ORDER_SEARCH_PARAMS>(factoryParams: 
     const orders: Ref<ORDERS> = sharedRef([], 'useUserOrder-orders');
     const loading: Ref<boolean> = sharedRef(false, 'useUserOrder-loading');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseUserOrderErrors> = sharedRef({}, 'useUserOrder-error');
+    const error: UnwrapRef<UseUserOrderErrors> = reactive({
+      search: null
+    });
 
     const search = async (searchParams): Promise<void> => {
       Logger.debug('useUserOrder.search', searchParams);
@@ -19,9 +21,9 @@ export function useUserOrderFactory<ORDERS, ORDER_SEARCH_PARAMS>(factoryParams: 
       try {
         loading.value = true;
         orders.value = await _factoryParams.searchOrders(searchParams);
-        error.value.search = null;
+        error.search = null;
       } catch (err) {
-        error.value.search = err;
+        error.search = err;
         Logger.error('useUserOrder/search', err);
       } finally {
         loading.value = false;
@@ -32,7 +34,7 @@ export function useUserOrderFactory<ORDERS, ORDER_SEARCH_PARAMS>(factoryParams: 
       orders: computed(() => orders.value),
       search,
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 }

--- a/packages/core/core/src/factories/useUserShippingFactory.ts
+++ b/packages/core/core/src/factories/useUserShippingFactory.ts
@@ -1,4 +1,4 @@
-import { Ref, unref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, unref, computed, reactive } from '@vue/composition-api';
 import { UseUserShipping, Context, FactoryParams, UseUserShippingErrors, CustomQuery } from '../types';
 import { sharedRef, Logger, mask, configureFactoryParams } from '../utils';
 
@@ -47,13 +47,13 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
     const shipping: Ref<USER_SHIPPING> = sharedRef({}, 'useUserShipping-shipping');
     const _factoryParams = configureFactoryParams(factoryParams);
     const readonlyShipping: Readonly<USER_SHIPPING> = unref(shipping);
-    const error: Ref<UseUserShippingErrors> = sharedRef({
+    const error: UnwrapRef<UseUserShippingErrors> = reactive({
       addAddress: null,
       deleteAddress: null,
       updateAddress: null,
       load: null,
       setDefaultAddress: null
-    }, 'useUserShipping-error');
+    });
 
     const addAddress = async ({ address, customQuery }) => {
       Logger.debug('useUserShipping.addAddress', mask(address));
@@ -65,9 +65,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.addAddress = null;
+        error.addAddress = null;
       } catch (err) {
-        error.value.addAddress = err;
+        error.addAddress = err;
         Logger.error('useUserShipping/addAddress', err);
       } finally {
         loading.value = false;
@@ -84,9 +84,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.deleteAddress = null;
+        error.deleteAddress = null;
       } catch (err) {
-        error.value.deleteAddress = err;
+        error.deleteAddress = err;
         Logger.error('useUserShipping/deleteAddress', err);
       } finally {
         loading.value = false;
@@ -103,9 +103,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.updateAddress = null;
+        error.updateAddress = null;
       } catch (err) {
-        error.value.updateAddress = err;
+        error.updateAddress = err;
         Logger.error('useUserShipping/updateAddress', err);
       } finally {
         loading.value = false;
@@ -120,9 +120,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
         shipping.value = await _factoryParams.load({
           shipping: readonlyShipping
         });
-        error.value.load = null;
+        error.load = null;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useUserShipping/load', err);
       } finally {
         loading.value = false;
@@ -139,9 +139,9 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
           shipping: readonlyShipping,
           customQuery
         });
-        error.value.setDefaultAddress = null;
+        error.setDefaultAddress = null;
       } catch (err) {
-        error.value.setDefaultAddress = err;
+        error.setDefaultAddress = err;
         Logger.error('useUserShipping/setDefaultAddress', err);
       } finally {
         loading.value = false;
@@ -151,7 +151,7 @@ export const useUserShippingFactory = <USER_SHIPPING, USER_SHIPPING_ITEM>(
     return {
       shipping: computed(() => shipping.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value),
+      error: computed(() => error),
       addAddress,
       deleteAddress,
       updateAddress,

--- a/packages/core/core/src/factories/useWishlistFactory.ts
+++ b/packages/core/core/src/factories/useWishlistFactory.ts
@@ -1,5 +1,5 @@
 import { UseWishlist, CustomQuery, Context, FactoryParams, UseWishlistErrors } from '../types';
-import { Ref, computed } from '@vue/composition-api';
+import { Ref, UnwrapRef, computed, reactive } from '@vue/composition-api';
 import { sharedRef, Logger, configureFactoryParams } from '../utils';
 
 export interface UseWishlistFactoryParams<WISHLIST, WISHLIST_ITEM, PRODUCT> extends FactoryParams {
@@ -29,12 +29,12 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT>(
     const loading: Ref<boolean> = sharedRef<boolean>(false, 'useWishlist-loading');
     const wishlist: Ref<WISHLIST> = sharedRef(null, 'useWishlist-wishlist');
     const _factoryParams = configureFactoryParams(factoryParams);
-    const error: Ref<UseWishlistErrors> = sharedRef({
+    const error: UnwrapRef<UseWishlistErrors> = reactive({
       addItem: null,
       removeItem: null,
       load: null,
       clear: null
-    }, 'useWishlist-error');
+    });
 
     const setWishlist = (newWishlist: WISHLIST) => {
       wishlist.value = newWishlist;
@@ -51,10 +51,10 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT>(
           product,
           customQuery
         });
-        error.value.addItem = null;
+        error.addItem = null;
         wishlist.value = updatedWishlist;
       } catch (err) {
-        error.value.addItem = err;
+        error.addItem = err;
         Logger.error('useWishlist/addItem', err);
       } finally {
         loading.value = false;
@@ -71,10 +71,10 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT>(
           product,
           customQuery
         });
-        error.value.removeItem = null;
+        error.removeItem = null;
         wishlist.value = updatedWishlist;
       } catch (err) {
-        error.value.removeItem = err;
+        error.removeItem = err;
         Logger.error('useWishlist/removeItem', err);
       } finally {
         loading.value = false;
@@ -88,9 +88,9 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT>(
       try {
         loading.value = true;
         wishlist.value = await _factoryParams.load({ customQuery });
-        error.value.load = null;
+        error.load = null;
       } catch (err) {
-        error.value.load = err;
+        error.load = err;
         Logger.error('useWishlist/load', err);
       } finally {
         loading.value = false;
@@ -105,10 +105,10 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT>(
         const updatedWishlist = await _factoryParams.clear({
           currentWishlist: wishlist.value
         });
-        error.value.clear = null;
+        error.clear = null;
         wishlist.value = updatedWishlist;
       } catch (err) {
-        error.value.clear = err;
+        error.clear = err;
         Logger.error('useWishlist/clear', err);
       } finally {
         loading.value = false;
@@ -133,7 +133,7 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT>(
       clear,
       setWishlist,
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error)
     };
   };
 

--- a/packages/core/core/src/utils/index.ts
+++ b/packages/core/core/src/utils/index.ts
@@ -1,25 +1,8 @@
 /* istanbul ignore file */
-
-import { onSSR, vsfRef, configureSSR } from './ssr';
-import { sharedRef } from './shared';
-import wrap from './wrap';
-import { Logger, registerLogger } from './logger';
-import mask from './logger/mask';
-import { useVSFContext, configureContext, generateContext, configureFactoryParams } from './context';
-import { integrationPlugin } from './nuxt';
-
-export {
-  wrap,
-  onSSR,
-  vsfRef,
-  configureSSR,
-  sharedRef,
-  Logger,
-  registerLogger,
-  mask,
-  configureContext,
-  useVSFContext,
-  configureFactoryParams,
-  generateContext,
-  integrationPlugin
-};
+export { useVSFContext, configureContext, generateContext, configureFactoryParams } from './context';
+export { Logger, registerLogger } from './logger';
+export { mask } from './logger/mask';
+export { integrationPlugin } from './nuxt';
+export { sharedRef } from './shared';
+export { onSSR, vsfRef, configureSSR } from './ssr';
+export { wrap } from './wrap';

--- a/packages/core/core/src/utils/logger/mask.ts
+++ b/packages/core/core/src/utils/logger/mask.ts
@@ -8,7 +8,7 @@ const maskAny = (el: any) => {
   return '***';
 };
 
-const mask = (el: any): any => {
+export const mask = (el: any): any => {
   if (typeof el === 'object' && !Array.isArray(el)) {
     return Object.keys(el).reduce((prev, key) => ({
       ...prev,
@@ -18,5 +18,3 @@ const mask = (el: any): any => {
 
   return maskAny(el);
 };
-
-export default mask;

--- a/packages/core/core/src/utils/wrap/index.ts
+++ b/packages/core/core/src/utils/wrap/index.ts
@@ -1,5 +1,5 @@
 import { isRef, ref, Ref, UnwrapRef } from '@vue/composition-api';
 
-export default function wrap<T>(element: Ref<UnwrapRef<T>> | T): Ref<UnwrapRef<T>> {
+export function wrap<T>(element: Ref<UnwrapRef<T>> | T): Ref<UnwrapRef<T>> {
   return isRef(element) ? element : ref<T>(element as T);
 }

--- a/packages/core/docs/changelog/5923.js
+++ b/packages/core/docs/changelog/5923.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fix reactivity of "error" objects in composables',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5923',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};

--- a/packages/core/docs/guide/composables.md
+++ b/packages/core/docs/guide/composables.md
@@ -369,30 +369,29 @@ However, if you still want to check interfaces, you could find them inside [`pac
 
 ### How to listen for errors?
 
-Let's imagine you have some global component for error notifications. You want to send information about every new error to this component. But how to know when a new error appears? You can observe an error object with a watcher:
+You can listen to changes of individual `error` properties or whole `error` objects from composables with a Vue.js watcher. 
 
-```ts
+```vue
+<script>
 import { useUiNotification } from '~/composables';
 
-const { cart, error } = useCart();
-const { send } = useUiNotification();
+export default {
+  setup() {
+    const { cart, error } = useCart();
 
-watch(() => ({...error.value}), (error, prevError) => {
-  if (error.addItem && error.addItem !== prevError.addItem)
-    send({ type: 'danger', message: error.addItem.message });
-  if (
-    error.removeItem &&
-    error.removeItem !== prevError.removeItem
-  )
-    send({ type: 'danger', message: error.removeItem.message });
-});
+    watch(() => error.value.addItem, (error, prevError) => {
+      // Listen to specific error, in this case
+    });
+
+    watch(() => ({ ...error.value }), (error, prevError) => {
+      // Listen to all cart errors
+    });
+  }
+};
+</script>
 ```
 
-In this example, we are using `useUiNotification` - a composable that handles notifications state. You can read more about it in the API reference.
-
-[//]: # 'TODO: This should be added to API reference'
-
-### How to customize graphql queries?
+### How to customize GraphQL queries?
 
 If your integration uses GraphQL API, you may need to change the default query that is being sent to fetch the data. That's quite a common case and Vue Storefront also provides the mechanism for this.
 

--- a/packages/core/docs/guide/composables.md
+++ b/packages/core/docs/guide/composables.md
@@ -377,7 +377,7 @@ import { useUiNotification } from '~/composables';
 
 export default {
   setup() {
-    const { cart, error } = useCart();
+    const { error } = useCart();
 
     watch(() => error.value.addItem, (error, prevError) => {
       // Listen to specific error, in this case


### PR DESCRIPTION
### Short Description of the PR
This PR fixes the reactivity of "error" objects. Currently, when an error occurs we only update the key inside of the "error" object. This doesn't work well with Vue.js devtools and the `watch` method.

To see the updated state in devtools, it's required to select another component and select the initial one again.

### Pull Request Checklist
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)
