### PR TITLE
[Bugfix] Make "register" params in "useUser" optional

### DIFF
--- a/packages/core/core/src/factories/useUserFactory.ts
+++ b/packages/core/core/src/factories/useUserFactory.ts
@@ -55,7 +55,7 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       }
     };
 
-    const register = async ({ user: providedUser }) => {
+    const register = async ({ user: providedUser } = { user: null }) => {
       Logger.debug('useUserFactory.register', providedUser);
       resetErrorValue();
 

--- a/packages/core/docs/changelog/5939.js
+++ b/packages/core/docs/changelog/5939.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Make `register` params in `useUser` optional',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5939',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};


### PR DESCRIPTION
### Short Description of the PR
Parameters in both `login` and `register` methods in `useUser` are optional. However, `register` throws an error when it's called without them, due to restructuring of the parameters.

### Pull Request Checklist
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)
