### PR TITLE
FIX: Disappearing selected filters on PLP reload

### DIFF
--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -387,16 +387,8 @@ export default {
       return category?.label || items[0].label;
     });
 
-    onSSR(async () => {
-      await search(th.getFacetsFromURL());
-    });
-
-    const { changeFilters, isFacetColor } = useUiHelpers();
-    const { toggleFilterSidebar } = useUiState();
     const selectedFilters = ref({});
-
-    onMounted(() => {
-      context.root.$scrollTo(context.root.$el, 2000);
+    const setSelectedFilters = () => {
       if (!facets.value.length) return;
       selectedFilters.value = facets.value.reduce((prev, curr) => ({
         ...prev,
@@ -404,6 +396,18 @@ export default {
           .filter(o => o.selected)
           .map(o => o.id)
       }), {});
+    };
+
+    onSSR(async () => {
+      await search(th.getFacetsFromURL());
+      setSelectedFilters();
+    });
+
+    const { changeFilters, isFacetColor } = useUiHelpers();
+    const { toggleFilterSidebar } = useUiState();
+
+    onMounted(() => {
+      context.root.$scrollTo(context.root.$el, 2000);
     });
 
     const isFilterSelected = (facet, option) => (selectedFilters.value[facet.id] || []).includes(option.id);

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -408,6 +408,7 @@ export default {
 
     onMounted(() => {
       context.root.$scrollTo(context.root.$el, 2000);
+      setSelectedFilters();
     });
 
     const isFilterSelected = (facet, option) => (selectedFilters.value[facet.id] || []).includes(option.id);

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -389,7 +389,7 @@ export default {
 
     const selectedFilters = ref({});
     const setSelectedFilters = () => {
-      if (!facets.value.length) return;
+      if (!facets.value.length || Object.keys(selectedFilters.value).length) return;
       selectedFilters.value = facets.value.reduce((prev, curr) => ({
         ...prev,
         [curr.id]: curr.options


### PR DESCRIPTION
Closes #5947 

### Short Description of the PR

There was a problem with displaying selected filters in the Category page. After we had selected a filter and the product list had been refreshed, no option checkbox was checked in the filters tab.

The logic responsible for setting selected filters was placed only inside the `onMounted` hook. It worked only on direct hit and not while navigating in SPA mode. I extracted the logic into a separate method (`setSelectedFilters`) and used it in the `onSSR` hook as well.  Now the filters should behave as expected.

*Placing the method in `onSSR` only did not work since the hook is not executed client-side on direct hit. Hence we need the method present in both places to secure all cases.

### Screenshots of Visual Changes before/after (if There Are Any)
Before: 
https://www.loom.com/share/90d686df7ff04c1ba0e3e5378912a72c

After (tested navigating in SPA mode, direct hit with query param change and force reload):
https://www.loom.com/share/6fa3884de92b43bab0c81ea772ffbfe1

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


