### PR TITLE
Fix currency internationalization

### DIFF
--- a/packages/commercetools/api-client/__tests__/api/createCart.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/createCart.spec.ts
@@ -6,6 +6,7 @@ describe('[commercetools-api-client] createCart', () => {
     const givenVariables = {
       acceptLanguage: ['en', 'de'],
       locale: 'en',
+      currency: 'USD',
       draft: {
         currency: 'USD',
         items: [],
@@ -50,7 +51,9 @@ describe('[commercetools-api-client] createCart', () => {
     const givenVariables = {
       acceptLanguage: ['en', 'de'],
       locale: 'en',
+      currency: 'USD',
       draft: {
+        country: 'US',
         currency: 'USD'
       }
     };

--- a/packages/commercetools/api-client/__tests__/api/getMe.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/getMe.spec.ts
@@ -5,7 +5,8 @@ describe('[commercetools-api-client] getMe', () => {
   it('fetches current user data', async () => {
     const givenVariables = {
       acceptLanguage: ['en', 'de'],
-      locale: 'en'
+      locale: 'en',
+      currency: 'USD'
     };
 
     const context = {

--- a/packages/commercetools/api-client/__tests__/api/updateCart.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/updateCart.spec.ts
@@ -7,6 +7,7 @@ const givenVariables = {
   acceptLanguage: ['en', 'de'],
   locale: 'en',
   id: 'cart id',
+  currency: 'USD',
   version: 1,
   actions: [{ addLineItem: {} }]
 };

--- a/packages/commercetools/api-client/src/api/createCart/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/createCart/defaultMutation.ts
@@ -4,7 +4,7 @@ import { CartFragment } from './../../fragments';
 export default gql`
   ${CartFragment}
 
-  mutation createCart($draft: MyCartDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
+  mutation createCart($draft: MyCartDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!, $storeKey: KeyReferenceInput) {
     cart: createMyCart(draft: $draft, storeKey: $storeKey) {
       ...DefaultCart
     }

--- a/packages/commercetools/api-client/src/api/createCart/index.ts
+++ b/packages/commercetools/api-client/src/api/createCart/index.ts
@@ -4,13 +4,15 @@ import gql from 'graphql-tag';
 import { CustomQuery } from '@vue-storefront/core';
 
 const createCart = async (context, cartDraft: CartData = {}, customQuery?: CustomQuery) => {
-  const { locale, acceptLanguage, currency } = context.config;
+  const { locale, acceptLanguage, currency, country } = context.config;
 
   const defaultVariables = {
     acceptLanguage,
     locale,
+    currency,
     draft: {
       currency,
+      country,
       ...cartDraft
     }
   };

--- a/packages/commercetools/api-client/src/api/createMyOrderFromCart/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/createMyOrderFromCart/defaultMutation.ts
@@ -4,7 +4,7 @@ import { OrderFragment } from '../../fragments';
 export default gql`
   ${OrderFragment}
 
-  mutation createMyOrderFromCart($draft: OrderMyCartCommand!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
+  mutation createMyOrderFromCart($draft: OrderMyCartCommand!, $locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!, $storeKey: KeyReferenceInput) {
     order: createMyOrderFromCart(draft: $draft, storeKey: $storeKey) {
       ...DefaultOrder
     }

--- a/packages/commercetools/api-client/src/api/createMyOrderFromCart/index.ts
+++ b/packages/commercetools/api-client/src/api/createMyOrderFromCart/index.ts
@@ -5,9 +5,12 @@ import gql from 'graphql-tag';
 import { CustomQuery } from '@vue-storefront/core';
 
 const createMyOrderFromCart = async (context, draft: OrderMyCartCommand, customQuery?: CustomQuery): Promise<OrderMutationResponse> => {
-  const { locale, acceptLanguage } = context.config;
-  const defaultVariables = { locale,
+  const { locale, acceptLanguage, currency } = context.config;
+
+  const defaultVariables = {
+    locale,
     acceptLanguage,
+    currency,
     draft
   };
 

--- a/packages/commercetools/api-client/src/api/customerSignMeIn/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeIn/defaultMutation.ts
@@ -5,7 +5,7 @@ export default gql`
   ${CustomerFragment}
   ${CartFragment}
 
-  mutation customerSignMeIn($draft: CustomerSignMeInDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
+  mutation customerSignMeIn($draft: CustomerSignMeInDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!, $storeKey: KeyReferenceInput) {
     user: customerSignMeIn(draft: $draft, storeKey: $storeKey) {
       customer {
         ...DefaultCustomer

--- a/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
@@ -3,10 +3,15 @@ import CustomerSignMeInMutation from './defaultMutation';
 import { SignInResponse } from './../../types/Api';
 
 const customerSignMeIn = async (context, draft: CustomerSignMeInDraft): Promise<SignInResponse> => {
-  const { locale, acceptLanguage } = context.config;
+  const { locale, acceptLanguage, currency } = context.config;
   const loginResponse = await context.client.mutate({
     mutation: CustomerSignMeInMutation,
-    variables: { draft, locale, acceptLanguage },
+    variables: {
+      draft,
+      locale,
+      acceptLanguage,
+      currency
+    },
     fetchPolicy: 'no-cache'
   }) as SignInResponse;
 

--- a/packages/commercetools/api-client/src/api/customerSignMeUp/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeUp/defaultMutation.ts
@@ -5,7 +5,7 @@ export default gql`
   ${CustomerFragment}
   ${CartFragment}
 
-  mutation customerSignMeUp($draft: CustomerSignMeUpDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
+  mutation customerSignMeUp($draft: CustomerSignMeUpDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!, $storeKey: KeyReferenceInput) {
     user: customerSignMeUp(draft: $draft, storeKey: $storeKey) {
       customer {
         ...DefaultCustomer

--- a/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
@@ -3,10 +3,15 @@ import CustomerSignMeUpMutation from './defaultMutation';
 import { SignInResponse } from '../../types/Api';
 
 const customerSignMeUp = async (context, draft: CustomerSignMeUpDraft): Promise<SignInResponse> => {
-  const { locale, acceptLanguage } = context.config;
+  const { locale, acceptLanguage, currency } = context.config;
   const registerResponse = await context.client.mutate({
     mutation: CustomerSignMeUpMutation,
-    variables: { draft, locale, acceptLanguage },
+    variables: {
+      draft,
+      locale,
+      acceptLanguage,
+      currency
+    },
     fetchPolicy: 'no-cache'
   }) as SignInResponse;
 

--- a/packages/commercetools/api-client/src/api/getCart/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getCart/defaultQuery.ts
@@ -4,7 +4,7 @@ import { CartFragment } from './../../fragments';
 export default gql`
   ${CartFragment}
 
-  query getCart($cartId: String!, $locale: Locale!, $acceptLanguage: [Locale!]) {
+  query getCart($cartId: String!, $locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!) {
     cart(id: $cartId) {
       ...DefaultCart
     }

--- a/packages/commercetools/api-client/src/api/getCart/index.ts
+++ b/packages/commercetools/api-client/src/api/getCart/index.ts
@@ -2,12 +2,16 @@ import { CartQueryResponse } from '../../types/Api';
 import defaultQuery from './defaultQuery';
 
 const getCart = async ({ config, client }, cartId: string): Promise<CartQueryResponse> => {
-  const { locale, acceptLanguage } = config;
+  const { locale, acceptLanguage, currency } = config;
+
   return await client.query({
     query: defaultQuery,
-    variables: { cartId,
+    variables: {
+      cartId,
       locale,
-      acceptLanguage },
+      acceptLanguage,
+      currency
+    },
     fetchPolicy: 'no-cache'
   });
 };

--- a/packages/commercetools/api-client/src/api/getMe/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getMe/defaultQuery.ts
@@ -4,7 +4,7 @@ import { CartFragment, CustomerFragment } from './../../fragments';
 const basicProfile = gql`
   ${CartFragment}
 
-  query getBasicProfile($locale: Locale!, $acceptLanguage: [Locale!]) {
+  query getBasicProfile($locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!) {
     me {
       activeCart {
         ...DefaultCart
@@ -17,7 +17,7 @@ const fullProfile = gql`
   ${CartFragment}
   ${CustomerFragment}
 
-  query getFullProfile($locale: Locale!, $acceptLanguage: [Locale!]) {
+  query getFullProfile($locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!) {
     me {
       activeCart {
         ...DefaultCart

--- a/packages/commercetools/api-client/src/api/getMe/index.ts
+++ b/packages/commercetools/api-client/src/api/getMe/index.ts
@@ -13,12 +13,13 @@ export interface OrdersData {
 }
 
 const getMe = async (context, params: GetMeParams = {}, customQuery?: CustomQuery) => {
-  const { locale, acceptLanguage } = context.config;
+  const { locale, acceptLanguage, currency } = context.config;
 
   const { customer }: GetMeParams = params;
   const defaultVariables = {
     locale,
-    acceptLanguage
+    acceptLanguage,
+    currency
   };
 
   const { getBasicProfile, getFullProfile } = context.extendQuery(customQuery, {

--- a/packages/commercetools/api-client/src/api/getOrders/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getOrders/defaultQuery.ts
@@ -4,7 +4,7 @@ import { OrderFragment } from '../../fragments';
 export default gql`
   ${OrderFragment}
 
-  query getMyOrders($where: String, $sort: [String!], $limit: Int, $offset: Int, $locale: Locale!, $acceptLanguage: [Locale!]) {
+  query getMyOrders($where: String, $sort: [String!], $limit: Int, $offset: Int, $locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!) {
     me {
       orders(where: $where, sort: $sort, limit: $limit, offset: $offset) {
         results {

--- a/packages/commercetools/api-client/src/api/getOrders/index.ts
+++ b/packages/commercetools/api-client/src/api/getOrders/index.ts
@@ -10,14 +10,16 @@ interface OrdersData {
 }
 
 const getOrders = async (context, params, customQuery?: CustomQuery) => {
-  const { locale, acceptLanguage } = context.config;
+  const { locale, acceptLanguage, currency } = context.config;
+
   const defaultVariables = {
     where: buildOrderWhere(params),
     sort: params.sort,
     limit: params.limit,
     offset: params.offset,
     acceptLanguage,
-    locale
+    locale,
+    currency
   };
 
   const { getMyOrders } = context.extendQuery(

--- a/packages/commercetools/api-client/src/api/updateCart/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/updateCart/defaultMutation.ts
@@ -4,7 +4,7 @@ import { CartFragment } from './../../fragments';
 export default gql`
   ${CartFragment}
 
-  mutation updateCart($id: String!, $version: Long!, $actions: [MyCartUpdateAction!]!, $locale: Locale!, $acceptLanguage: [Locale!]) {
+  mutation updateCart($id: String!, $version: Long!, $actions: [MyCartUpdateAction!]!, $locale: Locale!, $acceptLanguage: [Locale!], $currency: Currency!) {
     cart: updateMyCart(id: $id, version: $version, actions: $actions) {
       ...DefaultCart
     }

--- a/packages/commercetools/api-client/src/api/updateCart/index.ts
+++ b/packages/commercetools/api-client/src/api/updateCart/index.ts
@@ -13,11 +13,12 @@ export interface UpdateCartParams {
 }
 
 const updateCart = async (context, params: UpdateCartParams, customQuery?: CustomQuery) => {
-  const { locale, acceptLanguage } = context.config;
+  const { locale, acceptLanguage, currency } = context.config;
   const defaultVariables = params
     ? {
       locale,
       acceptLanguage,
+      currency,
       ...params
     }
     : { acceptLanguage };

--- a/packages/commercetools/api-client/src/fragments/index.ts
+++ b/packages/commercetools/api-client/src/fragments/index.ts
@@ -92,7 +92,7 @@ export const LineItemFragment = `
     variant {
       id
       sku
-      price(currency: "USD") {
+      price(currency: $currency) {
         tiers {
           value {
             centAmount

--- a/packages/commercetools/api-client/src/helpers/apiClient/defaultSettings.ts
+++ b/packages/commercetools/api-client/src/helpers/apiClient/defaultSettings.ts
@@ -1,6 +1,7 @@
 export const defaultSettings = {
   locale: 'en',
   currency: 'USD',
+  country: 'US',
   acceptLanguage: ['en'],
   auth: {
     onTokenChange: () => {},

--- a/packages/commercetools/api-client/src/helpers/apiClient/defaultSettings.ts
+++ b/packages/commercetools/api-client/src/helpers/apiClient/defaultSettings.ts
@@ -1,5 +1,6 @@
 export const defaultSettings = {
   locale: 'en',
+  currency: 'USD',
   acceptLanguage: ['en'],
   auth: {
     onTokenChange: () => {},

--- a/packages/commercetools/api-client/src/index.server.ts
+++ b/packages/commercetools/api-client/src/index.server.ts
@@ -17,7 +17,6 @@ const onCreate = (settings: Config): { config: Config; client: ClientInstance } 
     ...settings,
     languageMap,
     acceptLanguage: languageMap[locale] || acceptLanguage,
-    currency: settings.currency || defaultSettings.currency,
     auth: settings.auth || defaultSettings.auth
   } as any as Config;
 
@@ -63,8 +62,8 @@ const getI18nConfig = (req, configuration) => {
   const cookieSettings = configuration.cookies || defaultSettings.cookies;
   const { currencyCookieName, countryCookieName, localeCookieName } = cookieSettings;
   const locale = req.cookies[localeCookieName] || configuration.locale || defaultSettings.locale;
-  const currency = req.cookies[currencyCookieName] || configuration.currency;
-  const country = req.cookies[countryCookieName] || configuration.country;
+  const currency = req.cookies[currencyCookieName] || configuration.currency || defaultSettings.currency;
+  const country = req.cookies[countryCookieName] || configuration.country || defaultSettings.country;
 
   return { currency, country, locale };
 };

--- a/packages/commercetools/api-client/src/index.server.ts
+++ b/packages/commercetools/api-client/src/index.server.ts
@@ -17,6 +17,7 @@ const onCreate = (settings: Config): { config: Config; client: ClientInstance } 
     ...settings,
     languageMap,
     acceptLanguage: languageMap[locale] || acceptLanguage,
+    currency: settings.currency || defaultSettings.currency,
     auth: settings.auth || defaultSettings.auth
   } as any as Config;
 

--- a/packages/commercetools/theme/middleware.config.js
+++ b/packages/commercetools/theme/middleware.config.js
@@ -21,7 +21,9 @@ module.exports = {
             'manage_my_shopping_lists:vsf-ct-dev',
             'view_published_products:vsf-ct-dev'
           ]
-        }
+        },
+        currency: 'USD',
+        country: 'US'
       }
     }
   }

--- a/packages/commercetools/theme/middleware.config.js
+++ b/packages/commercetools/theme/middleware.config.js
@@ -21,9 +21,7 @@ module.exports = {
             'manage_my_shopping_lists:vsf-ct-dev',
             'view_published_products:vsf-ct-dev'
           ]
-        },
-        currency: 'USD',
-        country: 'US'
+        }
       }
     }
   }

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -97,13 +97,7 @@ export default {
     currency: 'USD',
     country: 'US',
     countries: [
-      { name: 'US',
-        label: 'United States',
-        states: [
-          'California',
-          'Nevada'
-        ]
-      },
+      { name: 'US', label: 'United States', states: ['California', 'Nevada'] },
       { name: 'AT', label: 'Austria' },
       { name: 'DE', label: 'Germany' },
       { name: 'NL', label: 'Netherlands' }
@@ -116,7 +110,7 @@ export default {
       { code: 'en', label: 'English', file: 'en.js', iso: 'en' },
       { code: 'de', label: 'German', file: 'de.js', iso: 'de' }
     ],
-    defaultLocale: 'en',
+    defaultLocale: 'de',
     lazy: true,
     seo: true,
     langDir: 'lang/',

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -104,32 +104,17 @@ export default {
           'Nevada'
         ]
       },
-      { name: 'AT',
-        label: 'Austria' },
-      { name: 'DE',
-        label: 'Germany' },
-      { name: 'NL',
-        label: 'Netherlands' }
+      { name: 'AT', label: 'Austria' },
+      { name: 'DE', label: 'Germany' },
+      { name: 'NL', label: 'Netherlands' }
     ],
     currencies: [
-      { name: 'EUR',
-        label: 'Euro' },
-      { name: 'USD',
-        label: 'Dollar' }
+      { name: 'EUR', label: 'Euro' },
+      { name: 'USD', label: 'Dollar' }
     ],
     locales: [
-      {
-        code: 'en',
-        label: 'English',
-        file: 'en.js',
-        iso: 'en'
-      },
-      {
-        code: 'de',
-        label: 'German',
-        file: 'de.js',
-        iso: 'de'
-      }
+      { code: 'en', label: 'English', file: 'en.js', iso: 'en' },
+      { code: 'de', label: 'German', file: 'de.js', iso: 'de' }
     ],
     defaultLocale: 'en',
     lazy: true,

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -1,4 +1,5 @@
 import webpack from 'webpack';
+import { VSF_LOCALE_COOKIE } from '@vue-storefront/core';
 
 export default {
   mode: 'universal',
@@ -130,7 +131,7 @@ export default {
       }
     },
     detectBrowserLanguage: {
-      cookieKey: 'vsf-locale'
+      cookieKey: VSF_LOCALE_COOKIE
     }
   },
   styleResources: {

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -110,7 +110,7 @@ export default {
       { code: 'en', label: 'English', file: 'en.js', iso: 'en' },
       { code: 'de', label: 'German', file: 'de.js', iso: 'de' }
     ],
-    defaultLocale: 'de',
+    defaultLocale: 'en',
     lazy: true,
     seo: true,
     langDir: 'lang/',

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -1,7 +1,21 @@
 /* istanbul ignore file */
-
 import { Ref } from '@vue/composition-api';
 import type { Request, Response } from 'express';
+
+/**
+ * Default name of the cookie storing active localization code
+ */
+export const VSF_LOCALE_COOKIE = 'vsf-locale';
+
+/**
+ * Default name of the cookie storing active currency code
+ */
+export const VSF_CURRENCY_COOKIE = 'vsf-currency';
+
+/**
+ * Default name of the cookie storing active country code
+ */
+export const VSF_COUNTRY_COOKIE = 'vsf-country';
 
 export type ComputedProperty<T> = Readonly<Ref<Readonly<T>>>;
 

--- a/packages/core/docs/changelog/5953.js
+++ b/packages/core/docs/changelog/5953.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Add plugin for creating locale, currency and country cookies',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5953',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};

--- a/packages/core/docs/commercetools/changelog/5953.js
+++ b/packages/core/docs/commercetools/changelog/5953.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fix hardcoded `USD` currency in GraphQL query',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/5953',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};

--- a/packages/core/nuxt-module/lib/module.js
+++ b/packages/core/nuxt-module/lib/module.js
@@ -11,7 +11,7 @@ const rawSourcesModule = require('./modules/raw-sources-loader');
 module.exports = function VueStorefrontNuxtModule (moduleOptions) {
   const defaultOptions = {
     coreDevelopment: false,
-    performance : {
+    performance: {
       httpPush: true,
       purgeCSS: {
         enabled: false,
@@ -51,7 +51,7 @@ module.exports = function VueStorefrontNuxtModule (moduleOptions) {
   }
 
   // Context plugin
-  this.addPlugin(path.resolve(__dirname, 'plugins/context.js'))
+  this.addPlugin(path.resolve(__dirname, 'plugins/context.js'));
   log.success('Installed Vue Storefront Context plugin');
 
   // SSR plugin
@@ -66,8 +66,15 @@ module.exports = function VueStorefrontNuxtModule (moduleOptions) {
   log.success('Installed VSF Logger plugin');
 
   // Context plugin
-  this.addPlugin(path.resolve(__dirname, 'plugins/e2e-testing.js'))
+  this.addPlugin(path.resolve(__dirname, 'plugins/e2e-testing.js'));
   log.success('Installed Vue Storefront E2E testing plugin');
+
+  // i18n-cookies plugin
+  this.addPlugin({
+    src: path.resolve(__dirname, 'plugins/i18n-cookies.js'),
+    options: this.options.i18n
+  });
+  log.success('Installed Internationalization Cookies plugin');
 
   // Composition API plugin
   this.addModule('@nuxtjs/composition-api');
@@ -85,6 +92,6 @@ module.exports = function VueStorefrontNuxtModule (moduleOptions) {
 
   // Raw sources loader
   rawSourcesModule.call(this, options);
-}
+};
 
-module.exports.meta = require('../package.json')
+module.exports.meta = require('../package.json');

--- a/packages/core/nuxt-module/lib/plugins/context.js
+++ b/packages/core/nuxt-module/lib/plugins/context.js
@@ -1,5 +1,4 @@
-
-import { configureContext } from '@vue-storefront/core'
+import { configureContext } from '@vue-storefront/core';
 import { useContext as useBaseContext } from '@nuxtjs/composition-api';
 
 const contextPlugin = (ctx, inject) => {
@@ -8,11 +7,11 @@ const contextPlugin = (ctx, inject) => {
   const useVSFContext = () => {
     const { $vsf, ...context } = useBaseContext();
 
-    return { $vsf, ...context, ...$vsf }
-  }
+    return { $vsf, ...context, ...$vsf };
+  };
 
   configureContext({ useVSFContext });
-  inject('sharedRefsMap', sharedMap)
+  inject('sharedRefsMap', sharedMap);
 };
 
 export default contextPlugin;

--- a/packages/core/nuxt-module/lib/plugins/e2e-testing.js
+++ b/packages/core/nuxt-module/lib/plugins/e2e-testing.js
@@ -5,7 +5,7 @@ const e2eTestingPlugin = (ctx) => {
     bind: (element, binding) => {
       const enabled = ctx.isDev || ctx.env.NUXT_ENV_E2E === true.toString();
 
-      return enabled && element.setAttribute(`data-e2e`, binding.value);
+      return enabled && element.setAttribute('data-e2e', binding.value);
     }
   });
 };

--- a/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
+++ b/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
@@ -1,0 +1,35 @@
+const { VSF_LOCALE_COOKIE, VSF_CURRENCY_COOKIE, VSF_COUNTRY_COOKIE } = require('@vue-storefront/core');
+
+const i18nCookiesPlugin = ({ $cookies }) => {
+  const i18n = <%= serialize(options) %>;
+
+  const settings = {
+    defaultLocale: i18n.defaultLocale || (i18n.locales.length && i18n.locales[0].code),
+    currency: i18n.currency || (i18n.currencies.length && i18n.currencies[0].name),
+    country: i18n.country || (i18n.countries.length && i18n.countries[0].name)
+  };
+
+  const missingFields = Object
+    .entries(settings)
+    .reduce((carry, [name, value]) => {
+      !value && carry.push(name);
+
+      return carry;
+    }, []);
+
+  if (missingFields.length) {
+    throw new Error(`Following fields are missing in the i18n configuration: ${ missingFields.join(', ') }`);
+  }
+
+  const cookieOptions = {
+    path: '/',
+    sameSite: 'lax',
+    expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)) // Year from now
+  };
+  
+  !$cookies.get(VSF_LOCALE_COOKIE) && $cookies.set(VSF_LOCALE_COOKIE, settings.defaultLocale, cookieOptions);
+  !$cookies.get(VSF_CURRENCY_COOKIE) && $cookies.set(VSF_CURRENCY_COOKIE, settings.currency, cookieOptions);
+  !$cookies.get(VSF_COUNTRY_COOKIE) && $cookies.set(VSF_COUNTRY_COOKIE, settings.country, cookieOptions);
+};
+
+export default i18nCookiesPlugin;

--- a/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
+++ b/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
@@ -1,4 +1,4 @@
-const { VSF_LOCALE_COOKIE, VSF_CURRENCY_COOKIE, VSF_COUNTRY_COOKIE } = require('@vue-storefront/core');
+const { VSF_CURRENCY_COOKIE, VSF_COUNTRY_COOKIE } = require('@vue-storefront/core');
 
 const i18nCookiesPlugin = ({ $cookies }) => {
   const i18n = <%= serialize(options) %>;
@@ -27,7 +27,6 @@ const i18nCookiesPlugin = ({ $cookies }) => {
     expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)) // Year from now
   };
   
-  !$cookies.get(VSF_LOCALE_COOKIE) && $cookies.set(VSF_LOCALE_COOKIE, settings.defaultLocale, cookieOptions);
   !$cookies.get(VSF_CURRENCY_COOKIE) && $cookies.set(VSF_CURRENCY_COOKIE, settings.currency, cookieOptions);
   !$cookies.get(VSF_COUNTRY_COOKIE) && $cookies.set(VSF_COUNTRY_COOKIE, settings.country, cookieOptions);
 };

--- a/packages/core/nuxt-module/lib/plugins/logger.js
+++ b/packages/core/nuxt-module/lib/plugins/logger.js
@@ -1,6 +1,6 @@
 import { registerLogger } from '@vue-storefront/core'
 
-const loggerPlugin = (app) => {
+const loggerPlugin = (ctx) => {
   const { verbosity, customLogger, ...args } = <%= serialize(options) %>;
   registerLogger(customLogger || args, verbosity || 'error')
 };

--- a/packages/core/nuxt-module/lib/plugins/ssr.js
+++ b/packages/core/nuxt-module/lib/plugins/ssr.js
@@ -1,17 +1,16 @@
-
-import { configureSSR } from '@vue-storefront/core'
+import { configureSSR } from '@vue-storefront/core';
 import { ssrRef, getCurrentInstance, onServerPrefetch } from '@nuxtjs/composition-api';
 
-const hasRouteChanged = (vm) => {
-  const { from } = vm.$router.app.context;
-  const { current } = vm.$router.history
+const hasRouteChanged = (ctx) => {
+  const { from } = ctx.$router.app.context;
+  const { current } = ctx.$router.history;
 
   if (!from) {
-    return false
+    return false;
   }
 
-  return from.fullPath !== current.fullPath
-}
+  return from.fullPath !== current.fullPath;
+};
 
 const ssrPlugin = () => {
   configureSSR({


### PR DESCRIPTION
### Short Description of the PR
This PR fixes hardcoded `USD` currency in one of the main GraphQL fragments we use in `useCart` and `useProduct` in the `commercetools` integration.

Additionally, I created a new plugin in `@vue-storefront/nuxt` package, that creates cookies for currently active locale, currency, and country. 

### Pull Request Checklist
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)
