### PR TITLE
Fix wrong prices after coupon in Cart/Checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changing regex responsible for UnicodeAlpha validation and added unit tests - @lukaszjedrasik ([#5340](https://github.com/vuestorefront/vue-storefront/issues/5340))
 - Bugfix for problems with global state in SSR during concurrently requests from different stores - @cewald (#5639)
 - Solves the use of attributes without options as filters in the category pages. - @michael-zangirolami-eleva ([#5845](https://forum.vuestorefront.io/t/category-ids-breaks-on-options-key/2194))
+- Fix wrong prices after coupon code in cart/checkout - @lukaszjedrasik ([#4460](https://github.com/vuestorefront/vue-storefront/issues/4460))
 
 ### Changed / Improved
 

--- a/core/modules/cart/helpers/getProductPrice.ts
+++ b/core/modules/cart/helpers/getProductPrice.ts
@@ -1,0 +1,53 @@
+import { onlineHelper } from '@vue-storefront/core/helpers';
+import config from 'config';
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem';
+
+interface ItemPrices {
+  special: number,
+  original: number,
+  regular: number
+}
+
+const getProductPrice = (product: CartItem): ItemPrices => {
+  if (!product) {
+    return {
+      special: null,
+      original: null,
+      regular: null
+    };
+  }
+
+  const { isOnline } = onlineHelper;
+  const { cart: { displayItemDiscounts }, tax: { finalPriceIncludesTax } } = config;
+  // @ts-ignore
+  const { price_incl_tax, original_price_incl_tax, regular_price, totals, qty } = product;
+
+  if (!displayItemDiscounts || !isOnline) {
+    return {
+      special: price_incl_tax * qty,
+      original: original_price_incl_tax * qty,
+      regular: (original_price_incl_tax || price_incl_tax) * qty
+    }
+  } else if (isOnline && totals) {
+    if (finalPriceIncludesTax) {
+      return {
+        special: (totals.row_total + totals.tax_amount) - totals.discount_amount,
+        original: totals.row_total_incl_tax,
+        regular: totals.row_total_incl_tax
+      }
+    } else {
+      return {
+        special: totals.row_total - totals.discount_amount,
+        original: totals.row_total,
+        regular: totals.row_total
+      }
+    }
+  }
+  return {
+    special: null,
+    original: null,
+    regular: regular_price
+  }
+}
+
+export default getProductPrice;

--- a/core/modules/cart/helpers/getProductPrice.ts
+++ b/core/modules/cart/helpers/getProductPrice.ts
@@ -24,22 +24,22 @@ const getProductPrice = (product: CartItem): ItemPrices => {
 
   if (!displayItemDiscounts || !isOnline) {
     return {
-      special: price_incl_tax * qty,
-      original: original_price_incl_tax * qty,
+      special: null,
+      original: null,
       regular: (original_price_incl_tax || price_incl_tax) * qty
     }
   } else if (isOnline && totals) {
     if (finalPriceIncludesTax) {
       return {
-        special: (totals.row_total + totals.tax_amount) - totals.discount_amount,
-        original: totals.row_total_incl_tax,
-        regular: totals.row_total_incl_tax
+        special: totals.discount_amount ? (totals.row_total + totals.tax_amount) - totals.discount_amount : null,
+        original: totals.discount_amount ? totals.row_total_incl_tax : null,
+        regular: !totals.discount_amount ? totals.row_total_incl_tax : null
       }
     } else {
       return {
-        special: totals.row_total - totals.discount_amount,
-        original: totals.row_total,
-        regular: totals.row_total
+        special: totals.discount_amount ? totals.row_total - totals.discount_amount : null,
+        original: totals.discount_amount ? totals.row_total : null,
+        regular: !totals.discount_amount ? totals.row_total : null
       }
     }
   }

--- a/core/modules/cart/helpers/index.ts
+++ b/core/modules/cart/helpers/index.ts
@@ -16,6 +16,7 @@ import getProductConfiguration from './getProductConfiguration'
 import createOrderData from './createOrderData'
 import createShippingInfoData from './createShippingInfoData'
 import * as syncCartWhenLocalStorageChange from './syncCartWhenLocalStorageChange'
+import getProductPrice from './getProductPrice';
 
 export {
   cartCacheHandlerFactory,
@@ -33,6 +34,7 @@ export {
   getThumbnailForProduct,
   getProductOptions,
   getProductConfiguration,
+  getProductPrice,
   createOrderData,
   createShippingInfoData,
   syncCartWhenLocalStorageChange

--- a/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
+++ b/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
@@ -1,0 +1,183 @@
+import getProductPrice from './../../../helpers/getProductPrice';
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem';
+import { onlineHelper } from '@vue-storefront/core/helpers'
+import config from 'config';
+
+jest.mock('@vue-storefront/core/helpers', () => ({
+  onlineHelper: {
+    get isOnline () {
+      return true
+    }
+  },
+  once: jest.fn()
+}));
+
+describe('Cart getProductPrice', () => {
+  const isOnlineSpy = jest.spyOn(onlineHelper, 'isOnline', 'get');
+
+  it('returns empty prices when product object is empty', () => {
+    const result = getProductPrice(null);
+    const expectedResult = {
+      special: null,
+      original: null,
+      regular: null
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('returns prices when displayItemDiscounts is equals false', () => {
+    isOnlineSpy.mockReturnValueOnce(false);
+    config.cart.displayItemDiscounts = false;
+    const mockedProduct = {
+      price_incl_tax: 24,
+      original_price_incl_tax: 24,
+      qty: 1
+    } as any as CartItem;
+
+    const result = getProductPrice(mockedProduct);
+    const expectedResult = {
+      special: 24,
+      original: 24,
+      regular: 24
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('uses price_incl_tax when original_price_incl_tax equals 0', () => {
+    isOnlineSpy.mockReturnValueOnce(false);
+    config.cart.displayItemDiscounts = true;
+    const mockedProduct = {
+      price_incl_tax: 24,
+      original_price_incl_tax: 0,
+      qty: 1
+    } as any as CartItem;
+
+    const result = getProductPrice(mockedProduct);
+    const expectedResult = {
+      special: 24,
+      original: 0,
+      regular: 24
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('returns totals prices without tax and without coupon', () => {
+    isOnlineSpy.mockReturnValueOnce(true);
+    config.tax.finalPriceIncludesTax = false;
+    config.cart.displayItemDiscounts = true;
+    const mockedProduct = {
+      price_incl_tax: 24,
+      original_price_incl_tax: 24,
+      totals: {
+        row_total: 24,
+        discount_amount: 0
+      },
+      qty: 1
+    } as any as CartItem;
+
+    const result = getProductPrice(mockedProduct);
+    const expectedResult = {
+      special: 24,
+      original: 24,
+      regular: 24
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('returns totals prices without tax and with coupon', () => {
+    isOnlineSpy.mockReturnValueOnce(true);
+    config.tax.finalPriceIncludesTax = false;
+    config.cart.displayItemDiscounts = true;
+    const mockedProduct = {
+      price_incl_tax: 24,
+      original_price_incl_tax: 24,
+      totals: {
+        row_total: 24,
+        discount_amount: 5
+      },
+      qty: 1
+    } as any as CartItem;
+
+    const result = getProductPrice(mockedProduct);
+    const expectedResult = {
+      special: 19,
+      original: 24,
+      regular: 24
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('returns totals prices with tax and without coupon', () => {
+    isOnlineSpy.mockReturnValueOnce(true);
+    config.tax.finalPriceIncludesTax = true;
+    config.cart.displayItemDiscounts = true;
+    const mockedProduct = {
+      price_incl_tax: 24,
+      original_price_incl_tax: 24,
+      totals: {
+        row_total: 24,
+        row_total_incl_tax: 25.98,
+        tax_amount: 1.98,
+        discount_amount: 0
+      },
+      qty: 1
+    } as any as CartItem;
+
+    const result = getProductPrice(mockedProduct);
+    const expectedResult = {
+      special: 25.98,
+      original: 25.98,
+      regular: 25.98
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('returns totals prices with tax and with coupon', () => {
+    isOnlineSpy.mockReturnValueOnce(true);
+    config.tax.finalPriceIncludesTax = true;
+    config.cart.displayItemDiscounts = true;
+    const mockedProduct = {
+      price_incl_tax: 24,
+      original_price_incl_tax: 24,
+      totals: {
+        row_total: 24,
+        row_total_incl_tax: 25.98,
+        tax_amount: 1.57,
+        discount_amount: 5
+      },
+      qty: 1
+    } as any as CartItem;
+
+    const result = getProductPrice(mockedProduct);
+    const expectedResult = {
+      special: 20.57,
+      original: 25.98,
+      regular: 25.98
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('returns regular price when totals doesn\'t exist or displayItemDiscounts is equals false', () => {
+    isOnlineSpy.mockReturnValueOnce(true);
+    const mockedProduct = {
+      regular_price: 24,
+      qty: 1
+    } as any as CartItem;
+
+    const result = getProductPrice(mockedProduct);
+    const expectedResult = {
+      special: null,
+      original: null,
+      regular: 24
+    };
+
+    expect(result).toEqual(expectedResult);
+  })
+});

--- a/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
+++ b/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
@@ -26,7 +26,7 @@ describe('Cart getProductPrice', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  it('returns prices when displayItemDiscounts is equals false', () => {
+  it('returns prices when displayItemDiscounts equals false', () => {
     isOnlineSpy.mockReturnValueOnce(false);
     config.cart.displayItemDiscounts = false;
     const mockedProduct = {

--- a/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
+++ b/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
@@ -37,8 +37,8 @@ describe('Cart getProductPrice', () => {
 
     const result = getProductPrice(mockedProduct);
     const expectedResult = {
-      special: 24,
-      original: 24,
+      special: null,
+      original: null,
       regular: 24
     };
 
@@ -56,8 +56,8 @@ describe('Cart getProductPrice', () => {
 
     const result = getProductPrice(mockedProduct);
     const expectedResult = {
-      special: 24,
-      original: 0,
+      special: null,
+      original: null,
       regular: 24
     };
 
@@ -80,8 +80,8 @@ describe('Cart getProductPrice', () => {
 
     const result = getProductPrice(mockedProduct);
     const expectedResult = {
-      special: 24,
-      original: 24,
+      special: null,
+      original: null,
       regular: 24
     };
 
@@ -106,7 +106,7 @@ describe('Cart getProductPrice', () => {
     const expectedResult = {
       special: 19,
       original: 24,
-      regular: 24
+      regular: null
     };
 
     expect(result).toEqual(expectedResult);
@@ -130,8 +130,8 @@ describe('Cart getProductPrice', () => {
 
     const result = getProductPrice(mockedProduct);
     const expectedResult = {
-      special: 25.98,
-      original: 25.98,
+      special: null,
+      original: null,
       regular: 25.98
     };
 
@@ -158,7 +158,7 @@ describe('Cart getProductPrice', () => {
     const expectedResult = {
       special: 20.57,
       original: 25.98,
-      regular: 25.98
+      regular: null
     };
 
     expect(result).toEqual(expectedResult);

--- a/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
+++ b/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
@@ -164,7 +164,7 @@ describe('Cart getProductPrice', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  it('returns regular price when totals doesn\'t exist or displayItemDiscounts is equals false', () => {
+  it('returns regular price when totals doesn\'t exist or displayItemDiscounts equals false', () => {
     isOnlineSpy.mockReturnValueOnce(true);
     const mockedProduct = {
       regular_price: 24,

--- a/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
+++ b/core/modules/cart/test/unit/helpers/getProductPrice.spec.ts
@@ -15,7 +15,7 @@ jest.mock('@vue-storefront/core/helpers', () => ({
 describe('Cart getProductPrice', () => {
   const isOnlineSpy = jest.spyOn(onlineHelper, 'isOnline', 'get');
 
-  it('returns empty prices when product object is empty', () => {
+  it('returns empty prices when product object is falsy', () => {
     const result = getProductPrice(null);
     const expectedResult = {
       special: null,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4460

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
- moved product prices calculations logic to a new helper called`getProductPrice`
- added unit test for `getProductPrice`
- related PR from default theme: https://github.com/vuestorefront/vsf-default/pull/63
- related PR from capybara theme https://github.com/vuestorefront/vsf-capybara/pull/650

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [x] Default Theme
- [ ] Capybara Theme
- [x] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


