### PR TITLE
fix: OS-125 update cli #5999

### DIFF
--- a/packages/core/cli/src/scripts/createProject/index.ts
+++ b/packages/core/cli/src/scripts/createProject/index.ts
@@ -18,7 +18,7 @@ async function createProject({
     await shell.exec(`git clone ${repositoryLink} ${templatePath}`);
     removeFolder(templatePath, '.git');
     log.success('Project template initialized successfully. ');
-    log.info('Check out docs.vuestorefront.io/v2');
+    log.info('Check out https://docs.vuestorefront.io/v2');
   } catch (error) {
     log.error('Unable to get integration template from git repository');
   }

--- a/packages/core/cli/src/utils/getIntegrations.ts
+++ b/packages/core/cli/src/utils/getIntegrations.ts
@@ -4,5 +4,5 @@ export default {
   'Salesforce Commerce Cloud (beta)': 'https://github.com/ForkPoint/vsf-sfcc-template.git',
   'Shopify (beta)': 'https://github.com/vuestorefront/template-shopify.git',
   'Spryker (beta)': 'https://github.com/spryker/vsf-theme.git',
-  'Magento 2 (WIP - beta end of April)': 'https://github.com/vuestorefront/template-magento.git'
+  'Magento 2 (beta)': 'https://github.com/vuestorefront/template-magento.git'
 };

--- a/packages/core/docs/changelog/5999.js
+++ b/packages/core/docs/changelog/5999.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Update CLI - magento name, link to docs',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/5999',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Mateusz Pietrusiński',
+  linkToGitHubAccount: 'https://github.com/Mateuszpietrusinski'
+};

--- a/packages/core/docs/changelog/5999.js
+++ b/packages/core/docs/changelog/5999.js
@@ -1,8 +1,0 @@
-module.exports = {
-  description: 'Update CLI - magento name, link to docs',
-  link: 'https://github.com/vuestorefront/vue-storefront/issues/5999',
-  isBreaking: false,
-  breakingChanges: [],
-  author: 'Mateusz Pietrusiński',
-  linkToGitHubAccount: 'https://github.com/Mateuszpietrusinski'
-};


### PR DESCRIPTION
### Related Issues

closes #5999 [OS-125](https://vsf.atlassian.net/browse/OS-125)

### Short Description of the PR
- Updating integration name Magento 2 (Beta)
- Adding a missing protocol to docs address


### Screenshots of Visual Changes before/after (if There Are Any)
![Zrzut ekranu 2021-06-16 o 09 29 51](https://user-images.githubusercontent.com/24594740/122177643-1b117300-ce86-11eb-8963-a741cb26ea1d.png)


### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [x] Default Theme
- [x] Capybara Theme
- [x] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


