### PR TITLE
fix: set correct type for productPageVisited hook param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Awaiting addItem action call inside mergeServerItem action (#5165)
 - Moved `phoneNum` to proper branch - @lukaszjedrasik ([#5730](https://github.com/vuestorefront/vue-storefront/issues/5730))
 - Development hot-reload speed webpack config - ([#5559](https://github.com/vuestorefront/vue-storefront/issues/5559))
+- Set correct type for `productPageVisited` hook - ([#5997](https://github.com/vuestorefront/vue-storefront/issues/5997))
+
 ## [1.12.2] - 2020.07.28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Awaiting addItem action call inside mergeServerItem action (#5165)
 - Moved `phoneNum` to proper branch - @lukaszjedrasik ([#5730](https://github.com/vuestorefront/vue-storefront/issues/5730))
 - Development hot-reload speed webpack config - ([#5559](https://github.com/vuestorefront/vue-storefront/issues/5559))
-- Set correct type for `productPageVisited` hook - ([#5997](https://github.com/vuestorefront/vue-storefront/issues/5997))
+- Set correct type for `productPageVisited` hook - @lukaszjedrasik ([#5997](https://github.com/vuestorefront/vue-storefront/issues/5997))
 
 ## [1.12.2] - 2020.07.28
 

--- a/core/modules/catalog-next/hooks.ts
+++ b/core/modules/catalog-next/hooks.ts
@@ -1,5 +1,6 @@
-import { createListenerHook, createMutatorHook } from '@vue-storefront/core/lib/hooks'
+import { createListenerHook } from '@vue-storefront/core/lib/hooks'
 import { Category } from './types/Category';
+import Product from 'core/modules/catalog/types/Product';
 
 const {
   hook: categoryPageVisitedHook,
@@ -9,7 +10,7 @@ const {
 const {
   hook: productPageVisitedHook,
   executor: productPageVisitedExecutor
-} = createListenerHook<Category>()
+} = createListenerHook<Product>()
 
 /** Only for internal usage */
 const catalogHooksExecutors = {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5997 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Related to https://github.com/vuestorefront/vue-storefront/issues/5997, this PR set up the correct type for `productPageVisited` hook param.

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [x] Default Theme
- [x] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


