### PR TITLE
fix: #5565/empty payload clear current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESLint warnings caused by the double import - @lukaszjedrasik
 - Fix Order History Pagination - @AishwaryShrivastav / @lukaszjedrasik ([#4599](https://github.com/vuestorefront/vue-storefront/issues/4599))
 - Fix: Updating URL's params/query params with proper child SKU if options changes - @lukaszjedrasik ([#5981](https://github.com/vuestorefront/vue-storefront/issues/5981))
+- Fix: Passing `newToken: null` as a payload inside `clearCurrentUser` action - @lukaszjedrasik ([#5565](https://github.com/vuestorefront/vue-storefront/issues/5565))
 
 ### Changed / Improved
 

--- a/core/modules/user/store/actions.ts
+++ b/core/modules/user/store/actions.ts
@@ -221,7 +221,7 @@ const actions: ActionTree<UserState, RootState> = {
     }
   },
   clearCurrentUser ({ commit, dispatch }) {
-    commit(types.USER_TOKEN_CHANGED, '')
+    commit(types.USER_TOKEN_CHANGED, { newToken: null })
     commit(types.USER_GROUP_TOKEN_CHANGED, '')
     commit(types.USER_GROUP_CHANGED, null)
     commit(types.USER_INFO_LOADED, null)

--- a/core/modules/user/test/unit/store/actions.spec.ts
+++ b/core/modules/user/test/unit/store/actions.spec.ts
@@ -396,7 +396,7 @@ describe('User actions', () => {
 
       (userActions as any).clearCurrentUser(contextMock)
 
-      expect(contextMock.commit).toHaveBeenNthCalledWith(1, types.USER_TOKEN_CHANGED, '')
+      expect(contextMock.commit).toHaveBeenNthCalledWith(1, types.USER_TOKEN_CHANGED, { newToken: null })
       expect(contextMock.commit).toHaveBeenNthCalledWith(2, types.USER_GROUP_TOKEN_CHANGED, '')
       expect(contextMock.commit).toHaveBeenNthCalledWith(3, types.USER_GROUP_CHANGED, null)
       expect(contextMock.commit).toHaveBeenNthCalledWith(4, types.USER_INFO_LOADED, null)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5565 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Passing `{ newToken: null }` as a payload inside `clearCurrentUser` action.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

![Zrzut ekranu 2021-06-22 o 12 19 47](https://user-images.githubusercontent.com/40273258/122909557-9cb94300-d355-11eb-95c1-57a50f5e87f9.png)

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [x] Default Theme
- [x] Capybara Theme
- [x] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


