### PR TITLE
Bugfix: Adding coupon resets shipping method in cart totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Device module fix for shared instance. Vue.prototype.$device isn't accessible anymore (#5297)
 - Added `beforeBuildCacheKey` server hook (#5297)
 - Fixed some typo in docs (#5071)
+- Fix bug where adding/removing coupon would not honor the currently selected shipping method when syncing totals. (#6046)
 
 ### Changed / Improved
 

--- a/core/modules/cart/helpers/createOrderData.ts
+++ b/core/modules/cart/helpers/createOrderData.ts
@@ -45,8 +45,8 @@ const createOrderData = ({
       street: [paymentDetails.streetAddress],
       countryId: paymentDetails.country
     },
-    method_code: shipping && shipping.method_code ? shipping.method_code : null,
-    carrier_code: shipping && shipping.carrier_code ? shipping.carrier_code : null,
+    method_code: shippingDetails.shippingMethod || shipping && shipping.method_code ? shipping.method_code : null,
+    carrier_code: shippingDetails.shippingCarrier || shipping && shipping.carrier_code ? shipping.carrier_code : null,
     payment_method: payment && payment.code ? payment.code : null
   }
 }

--- a/core/modules/cart/helpers/createOrderData.ts
+++ b/core/modules/cart/helpers/createOrderData.ts
@@ -45,8 +45,8 @@ const createOrderData = ({
       street: [paymentDetails.streetAddress],
       countryId: paymentDetails.country
     },
-    method_code: shippingDetails.shippingMethod || shipping && shipping.method_code ? shipping.method_code : null,
-    carrier_code: shippingDetails.shippingCarrier || shipping && shipping.carrier_code ? shipping.carrier_code : null,
+    method_code: shippingDetails.shippingMethod || (shipping && shipping.method_code ? shipping.method_code : null),
+    carrier_code: shippingDetails.shippingCarrier || (shipping && shipping.carrier_code ? shipping.carrier_code : null),
     payment_method: payment && payment.code ? payment.code : null
   }
 }

--- a/core/modules/checkout/store/checkout/index.ts
+++ b/core/modules/checkout/store/checkout/index.ts
@@ -30,7 +30,8 @@ export const checkoutModule: Module<CheckoutState, RootState> = {
       region_id: 0,
       zipCode: '',
       phoneNumber: '',
-      shippingMethod: ''
+      shippingMethod: '',
+      shippingCarrier: ''
     },
     paymentDetails: {
       firstName: '',

--- a/core/modules/checkout/types/ShippingDetails.ts
+++ b/core/modules/checkout/types/ShippingDetails.ts
@@ -9,5 +9,6 @@ export default interface ShippingDetails {
   region_id: number | string,
   zipCode: string,
   phoneNumber: string,
-  shippingMethod: string
+  shippingMethod: string,
+  shippingCarrier: string
 }


### PR DESCRIPTION
### Related Issues
closes #6045

### Short Description of the PR
These changes checks if a shipping method/carrier is already set when doing the `syncTotals` after a coupon is added/removed.
Before it always used the default/first shipping method even if the user had selected another method in checkout.

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


