### PR TITLE
Redirect to 404 page when category does not exist

### DIFF
--- a/packages/core/docs/changelog/5871.js
+++ b/packages/core/docs/changelog/5871.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Redirect to 404 page when category page does not exist',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/5871',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Łukasz Jędrasik',
+  linkToGitHubAccount: 'https://github.com/lukaszjedrasik'
+};

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -389,7 +389,7 @@ export default {
 
       const category = items.find(({ isCurrent, items }) => isCurrent || items.find(({ isCurrent }) => isCurrent));
 
-      return category?.label || items[0]?.label;
+      return category?.label || items[0].label;
     });
 
     const selectedFilters = ref({});

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -236,7 +236,7 @@
             <span class="products__show-on-page__label">{{ $t('Show on page') }}</span>
             <LazyHydrate on-interaction>
               <SfSelect
-                :value="pagination.itemsPerPage.toString()"
+                :value="pagination && pagination.itemsPerPage ? pagination.itemsPerPage.toString() : ''"
                 class="products__items-per-page"
                 @input="th.changeItemsPerPage"
               >
@@ -372,7 +372,7 @@ export default {
     const uiState = useUiState();
     const { addItem: addItemToCart, isInCart } = useCart();
     const { addItem: addItemToWishlist, isInWishlist, removeItem: removeItemFromWishlist } = useWishlist();
-    const { result, search, loading } = useFacet();
+    const { result, search, loading, error } = useFacet();
 
     const products = computed(() => facetGetters.getProducts(result.value));
     const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
@@ -389,7 +389,7 @@ export default {
 
       const category = items.find(({ isCurrent, items }) => isCurrent || items.find(({ isCurrent }) => isCurrent));
 
-      return category?.label || items[0].label;
+      return category?.label || items[0]?.label;
     });
 
     const selectedFilters = ref({});
@@ -405,6 +405,7 @@ export default {
 
     onSSR(async () => {
       await search(th.getFacetsFromURL());
+      if (error?.value?.search) context.root.$nuxt.error({ statusCode: 404 });
       setSelectedFilters();
     });
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #5871 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Redirect to 404 page when category does not exist

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
#### Before:
![Zrzut ekranu 2021-07-5 o 10 20 36](https://user-images.githubusercontent.com/40273258/124567977-c047b780-de44-11eb-95fd-777455fefe25.png)

#### After:
![Zrzut ekranu 2021-07-5 o 10 20 12](https://user-images.githubusercontent.com/40273258/124568033-cfc70080-de44-11eb-94d0-7d9dc0298e24.png)

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


