### PR TITLE
[EN-284]: Not all queries in commercetools are wrapped in `gql` template literal

### DIFF
--- a/packages/commercetools/api-client/src/api/customerChangeMyPassword/index.ts
+++ b/packages/commercetools/api-client/src/api/customerChangeMyPassword/index.ts
@@ -1,9 +1,10 @@
+import gql from 'graphql-tag';
 import CustomerChangeMyPassword from './defaultMutation';
 import { ChangeMyPasswordResponse } from '../../types/Api';
 
 const customerChangeMyPassword = async ({ client }, version: any, currentPassword: string, newPassword: string): Promise<ChangeMyPasswordResponse> => {
   return await client.mutate({
-    mutation: CustomerChangeMyPassword,
+    mutation: gql`${CustomerChangeMyPassword}`,
     variables: {
       version,
       currentPassword,

--- a/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
@@ -1,3 +1,4 @@
+import gql from 'graphql-tag';
 import { CustomerSignMeInDraft } from '../../types/GraphQL';
 import CustomerSignMeInMutation from './defaultMutation';
 import { SignInResponse } from './../../types/Api';
@@ -5,7 +6,7 @@ import { SignInResponse } from './../../types/Api';
 const customerSignMeIn = async (context, draft: CustomerSignMeInDraft): Promise<SignInResponse> => {
   const { locale, acceptLanguage, currency } = context.config;
   const loginResponse = await context.client.mutate({
-    mutation: CustomerSignMeInMutation,
+    mutation: gql`${CustomerSignMeInMutation}`,
     variables: {
       draft,
       locale,

--- a/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
@@ -1,3 +1,4 @@
+import gql from 'graphql-tag';
 import { CustomerSignMeUpDraft } from '../../types/GraphQL';
 import CustomerSignMeUpMutation from './defaultMutation';
 import { SignInResponse } from '../../types/Api';
@@ -5,7 +6,7 @@ import { SignInResponse } from '../../types/Api';
 const customerSignMeUp = async (context, draft: CustomerSignMeUpDraft): Promise<SignInResponse> => {
   const { locale, acceptLanguage, currency } = context.config;
   const registerResponse = await context.client.mutate({
-    mutation: CustomerSignMeUpMutation,
+    mutation: gql`${CustomerSignMeUpMutation}`,
     variables: {
       draft,
       locale,

--- a/packages/commercetools/api-client/src/api/customerUpdateMe/index.ts
+++ b/packages/commercetools/api-client/src/api/customerUpdateMe/index.ts
@@ -1,9 +1,10 @@
+import gql from 'graphql-tag';
 import { changeCustomerEmailAction, setCustomerFirstNameAction, setCustomerLastNameAction } from '../../helpers/customer';
 import CustomerUpdateMeMutation from './defaultMutation';
 
 const customerUpdateMe = async ({ client }, currentUser, updatedUserData) => {
   const updateResponse = await client.mutate({
-    mutation: CustomerUpdateMeMutation,
+    mutation: gql`${CustomerUpdateMeMutation}`,
     variables: {
       version: currentUser.version,
       actions: [

--- a/packages/commercetools/api-client/src/api/getCart/index.ts
+++ b/packages/commercetools/api-client/src/api/getCart/index.ts
@@ -1,3 +1,4 @@
+import gql from 'graphql-tag';
 import { CartQueryResponse } from '../../types/Api';
 import defaultQuery from './defaultQuery';
 
@@ -5,7 +6,7 @@ const getCart = async ({ config, client }, cartId: string): Promise<CartQueryRes
   const { locale, acceptLanguage, currency } = config;
 
   return await client.query({
-    query: defaultQuery,
+    query: gql`${defaultQuery}`,
     variables: {
       cartId,
       locale,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Closes [EN-284](https://vsf.atlassian.net/browse/EN-284)

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Found and wrapped in gql all queries where the wrapper had been missing

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


