### PR TITLE
[EN-368]: "shippingInfo" cart data get erased using useShipping "save" method

### DIFF
--- a/packages/commercetools/composables/src/useShipping/index.ts
+++ b/packages/commercetools/composables/src/useShipping/index.ts
@@ -3,7 +3,12 @@ import { useCart } from '../useCart';
 import { cartActions } from '@vue-storefront/commercetools-api';
 import { Address } from './../types/GraphQL';
 
-const useShippingFactoryParams: UseShippingParams<Address, any> = {
+type ShippingParams = {
+  resetShippingMethods: boolean;
+  [x:string]: any
+}
+
+const useShippingFactoryParams: UseShippingParams<Address, ShippingParams> = {
   provide() {
     return {
       cart: useCart()
@@ -15,12 +20,12 @@ const useShippingFactoryParams: UseShippingParams<Address, any> = {
     }
     return context.cart.cart.value.shippingAddress;
   },
-  save: async (context: Context, { shippingDetails, customQuery }) => {
+  save: async (context: Context, { shippingDetails, customQuery, params = { resetShippingMethods: true } }) => {
     const cartResponse = await context.$ct.api.updateCart({
       id: context.cart.cart.value.id,
       version: context.cart.cart.value.version,
       actions: [
-        cartActions.setShippingMethodAction(),
+        ...(params.resetShippingMethods ? [cartActions.setShippingMethodAction()] : []),
         cartActions.setShippingAddressAction(shippingDetails)
       ]
     }, customQuery);
@@ -30,7 +35,7 @@ const useShippingFactoryParams: UseShippingParams<Address, any> = {
   }
 };
 
-const useShipping = useShippingFactory<Address, any>(useShippingFactoryParams);
+const useShipping = useShippingFactory<Address, ShippingParams>(useShippingFactoryParams);
 
 export {
   useShipping,

--- a/packages/core/docs/commercetools/composables/use-shipping.md
+++ b/packages/core/docs/commercetools/composables/use-shipping.md
@@ -25,6 +25,8 @@ type CustomQuery = {
 
     - `customQuery?: CustomQuery`
 
+  - `params?: ShippingParams`
+
 ```ts
 type Address = {
   __typename?: "Address";
@@ -57,6 +59,10 @@ type Address = {
 type CustomQuery = {
   updateCart: string
 }
+type ShippingParams = {
+  resetShippingMethods: boolean;
+  [x: string]: any;
+};
 ```
 - `shipping: Address` - a main data object that contains a shipping address.
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes [EN-368](https://vsf.atlassian.net/browse/EN-368)

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
`save` method of `useShipping` composable removes all shipping methods data from cart on every request. 
This PR implements additional parameter to `save` method that allows to keep / remove shipingInfo data on demand.
The defaults has been implemented to provide compatibility with current theme.

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues

- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


