### PR TITLE
refactor(core:logger): change the logger behavior to match the console

### DIFF
--- a/packages/core/core/src/utils/logger/defaultLogger.ts
+++ b/packages/core/core/src/utils/logger/defaultLogger.ts
@@ -1,10 +1,13 @@
 /* istanbul ignore file */
 
+import { makeMethod } from './makeMethod';
+import { LogName } from './types';
+
 const defaultLogger = {
-  debug: (message: any, ...args) => console.debug('[VSF][debug]', message, ...args),
-  info: (message: any, ...args) => console.info('[VSF][info]', message, ...args),
-  warn: (message: any, ...args) => console.warn('[VSF][warn]', message, ...args),
-  error: (message: any, ...args) => console.error('[VSF][error]', message, ...args)
+  debug: makeMethod(LogName.Debug, console.debug)(),
+  info: makeMethod(LogName.Info, console.info)(),
+  warn: makeMethod(LogName.Warn, console.warn)(),
+  error: makeMethod(LogName.Error, console.error)()
 };
 
 export default defaultLogger;

--- a/packages/core/core/src/utils/logger/makeMessageStyle.ts
+++ b/packages/core/core/src/utils/logger/makeMessageStyle.ts
@@ -1,0 +1,33 @@
+import { LogLevelStyle, LogName } from './types';
+import { mountLog } from './utils';
+
+export function makeMessageStyle(logEnum: LogName) {
+  switch (logEnum) {
+    case LogName.Error:
+      return mountLog(
+        '[VSF][error]',
+        LogLevelStyle.Error
+      );
+    case LogName.Info:
+      return mountLog(
+        '[VSF][info]',
+        LogLevelStyle.Info
+      );
+    case LogName.Warn:
+      return mountLog(
+        '[VSF][warn]',
+        LogLevelStyle.Warn
+      );
+    case LogName.Debug:
+      return mountLog(
+        '[VSF][debug]',
+        LogLevelStyle.Log
+      );
+    case LogName.None:
+    default:
+      return mountLog(
+        '[VSF]',
+        LogLevelStyle.Log
+      );
+  }
+}

--- a/packages/core/core/src/utils/logger/makeMethod.ts
+++ b/packages/core/core/src/utils/logger/makeMethod.ts
@@ -1,0 +1,11 @@
+import { LogName } from './types';
+import { makeMessageStyle } from './makeMessageStyle';
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function makeMethod(logEnum: LogName, fn: Function) {
+  return () => {
+    return Function.prototype.bind.apply(fn, [
+      console,
+      ...makeMessageStyle(logEnum)
+    ]);
+  };
+}

--- a/packages/core/core/src/utils/logger/types.ts
+++ b/packages/core/core/src/utils/logger/types.ts
@@ -1,0 +1,14 @@
+export enum LogName {
+  Error = 'error',
+  Info = 'info',
+  Debug = 'debug',
+  None = 'none',
+  Warn = 'warn',
+}
+
+export const LogLevelStyle = {
+  Log: 'background:#5ece7b; padding: 2px; border-radius: 0 2px 2px 0;  color: #fff;',
+  Info: 'background:#0468DB; padding: 2px; border-radius: 0 2px 2px 0;  color: #fff;',
+  Warn: 'background:#ecc713; padding: 2px; border-radius: 0 2px 2px 0;  color: #000;',
+  Error: 'background:#d12727; padding: 2px; border-radius: 0 2px 2px 0;  color: #fff'
+};

--- a/packages/core/core/src/utils/logger/utils.ts
+++ b/packages/core/core/src/utils/logger/utils.ts
@@ -1,0 +1,33 @@
+export type LogMessage = string[] | Error | Record<string, any> | string | boolean;
+
+export const getMessage = (message: LogMessage): string | undefined => {
+  if (Array.isArray(message)) return message.join(' | ');
+  if (message instanceof Error) return message.message;
+  if (typeof message === 'object') return JSON.stringify(message, null, 1);
+
+  const returnMessage = message as string || '';
+
+  return `${returnMessage}`;
+};
+
+export const detectNode: boolean = Object.prototype
+  .toString
+  .call(typeof process !== 'undefined'
+    ? process
+    : 0) === '[object process]' ||
+  process.env.APPLICATION_ENV === 'production';
+
+export const mountLog = (
+  name: string,
+  style: string
+) => {
+  if (detectNode) {
+    return [`${name}: `];
+  }
+
+  return [
+    `%c${name}%c:`,
+    style,
+    'background: transparent;'
+  ];
+};

--- a/packages/core/docs/changelog/6085.js
+++ b/packages/core/docs/changelog/6085.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'change the core logger behavior to match the console',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6085',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'bloodf',
+  linkToGitHubAccount: 'https://github.com/bloodf'
+};


### PR DESCRIPTION
### Short Description of the PR
I've added a more complete behavior to the Core Logger, to match the default console ones.

Where now the user can see the correct location of the logged point, and see where the error is coming from, or the information, without the need to search on the codebase.

I've added some styling on the logger so it can matches the behavior to info, log, warn and error.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
![Screen Shot 2021-07-18 at 15 50 07](https://user-images.githubusercontent.com/1626923/126078953-58df9054-cfa0-4fb5-a1fb-a0209ecea266.png)


### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


