### PR TITLE
Remove duplicate dependency

### DIFF
--- a/packages/core/nuxt-module/package.json
+++ b/packages/core/nuxt-module/package.json
@@ -20,8 +20,7 @@
     "nuxt-purgecss": "^1.0.0"
   },
   "devDependencies": {
-    "@nuxt/types": "^0.7.9",
-    "@nuxt/typescript-build": "^0.3.1"
+    "@nuxt/types": "^0.7.9"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Remove `@nuxt/typescript-build` dependency from `devDependencies` because the newer version is already registered in `dependencies`.