### PR TITLE
Bug/6099 missing dependency

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -13,13 +13,14 @@
   },
   "dependencies": {
     "@vue/composition-api": "1.0.0-beta.21",
-    "vue": "^2.6.11",
-    "lodash-es": "^4.17.15",
-    "express": "^4.17.1",
     "axios": "0.21.1",
-    "is-https": "^3.0.2"
+    "express": "^4.17.1",
+    "is-https": "^3.0.2",
+    "lodash-es": "^4.17.15",
+    "vue": "^2.6.11"
   },
   "devDependencies": {
+    "@nuxt/types": "^2.15.7",
     "@types/express": "^4.11.1",
     "@vue/test-utils": "^1.0.0-beta.30",
     "vue-template-compiler": "^2.6.x"

--- a/packages/core/docs/changelog/6089.js
+++ b/packages/core/docs/changelog/6089.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fixed incorrect method`',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/6089',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'jaydubb12',
+  linkToGitHubAccount: 'https://github.com/jaydubb12/vue-storefront'
+};

--- a/packages/core/docs/changelog/6099.js
+++ b/packages/core/docs/changelog/6099.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Remediated missing dependency`',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/6099',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'jaydubb12',
+  linkToGitHubAccount: 'https://github.com/jaydubb12/vue-storefront'
+};

--- a/packages/core/nuxt-theme-module/index.js
+++ b/packages/core/nuxt-theme-module/index.js
@@ -8,7 +8,7 @@ const chalk = require('chalk');
 const log = {
   info: (message) => consola.info(chalk.bold('VSF'), message),
   success: (message) => consola.success(chalk.bold('VSF'), message),
-  warning: (message) => consola.warning(chalk.bold('VSF'), message),
+  warning: (message) => consola.warn(chalk.bold('VSF'), message),
   error: (message) => consola.error(chalk.bold('VSF'), message)
 };
 


### PR DESCRIPTION
### Related Issues
#6098 

closes #
6099

### Short Description of the PR
Appends missing dependency to package.json.
NOTE, I used version 2.15.7 of the dependency which requires use of node 12


### Screenshots of Visual Changes before/after (if There Are Any)


### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


