### PR TITLE
smartphone only promo code input added

### DIFF
--- a/packages/commercetools/theme/pages/Checkout/Payment.vue
+++ b/packages/commercetools/theme/pages/Checkout/Payment.vue
@@ -45,6 +45,15 @@
         </div>
       </SfAccordionItem>
     </SfAccordion>
+    <div class="promo-code smartphone-only">
+      <SfInput
+        v-model="promoCode"
+        name="promoCode"
+        :label="$t('Enter promo code')"
+        class="sf-input--filled promo-code__input"
+      />
+      <SfButton class="promo-code__button" @click="() => applyCoupon({ couponCode: promoCode })">{{ $t('Apply') }}</SfButton>
+    </div>
     <SfTable class="sf-table--bordered table desktop-only">
       <SfTableHeading class="table__row">
         <SfTableHeader class="table__header table__image">{{ $t('Item') }}</SfTableHeader>
@@ -140,7 +149,8 @@ import {
   SfPrice,
   SfProperty,
   SfAccordion,
-  SfLink
+  SfLink,
+  SfInput
 } from '@storefront-ui/vue';
 import { ref, computed } from '@vue/composition-api';
 import { useMakeOrder, useCart, useBilling, useShipping, useShippingProvider, cartGetters } from '@vue-storefront/commercetools';
@@ -163,11 +173,12 @@ export default {
     SfProperty,
     SfAccordion,
     SfLink,
-    VsfPaymentProviderMock
+    VsfPaymentProviderMock,
+    SfInput
   },
   setup(_, context) {
     const { status: paymentReady } = usePaymentProviderMock();
-    const { cart, removeItem, load, setCart } = useCart();
+    const { cart, removeItem, load, setCart, applyCoupon } = useCart();
     const { shipping: shippingDetails, load: loadShippingDetails } = useShipping();
     const { load: loadShippingProvider, state } = useShippingProvider();
     const { billing: billingDetails, load: loadBillingDetails } = useBilling();
@@ -177,6 +188,7 @@ export default {
     const { order, make, loading } = useMakeOrder();
 
     const terms = ref(false);
+    const promoCode = ref('');
 
     onSSR(async () => {
       await load();
@@ -205,7 +217,9 @@ export default {
       tableHeaders: ['Description', 'Size', 'Color', 'Quantity', 'Amount'],
       cartGetters,
       getShippingMethodPrice,
-      paymentReady
+      paymentReady,
+      promoCode,
+      applyCoupon
     };
   }
 };
@@ -324,5 +338,22 @@ export default {
   --divider-border-color: var(--c-primary);
   --divider-width: 100%;
   --divider-margin: 0 0 var(--spacer-base) 0;
+}
+
+.promo-code {
+  margin-bottom: var(--spacer-base);
+  display: flex;
+  align-items: flex-start;
+  &__button {
+    --button-width: 6.3125rem;
+    --button-height: var(--spacer-lg);
+    &:hover {
+      --button-box-shadow-opacity: 0
+    }
+  }
+  &__input {
+    --input-background: var(--c-light);
+    flex: 1;
+  }
 }
 </style>

--- a/packages/core/docs/commercetools/changelog/6112.js
+++ b/packages/core/docs/commercetools/changelog/6112.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Smartphone only promo code input added',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6112',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'vn-vlad',
+  linkToGitHubAccount: 'https://github.com/vn-vlad'
+};


### PR DESCRIPTION
### Related Issues
https://vsf.atlassian.net/browse/EN-358

### Short Description of the PR
During checkout in desktop version user has an option to enter and apply promotional code. 
This option is not available in mobile view.


### Screenshots of Visual Changes before/after (if There Are Any)
<img width="422" alt="Снимок экрана 2021-07-22 в 17 33 42" src="https://user-images.githubusercontent.com/8132581/126657074-068743f9-89b9-471b-a375-a9bdca52a07b.png">
