### PR TITLE
fix: fixed Nuxt-CLI spamming babel warning due plugin configuration

### DIFF
--- a/packages/boilerplate/theme/nuxt.config.js
+++ b/packages/boilerplate/theme/nuxt.config.js
@@ -99,6 +99,11 @@ export default {
     scss: [require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] })]
   },
   build: {
+    babel: {
+      plugins: [
+        ['@babel/plugin-proposal-private-methods', { loose: true }],
+      ],
+    },
     transpile: [
       'vee-validate/dist/rules'
     ],

--- a/packages/boilerplate/theme/nuxt.config.js
+++ b/packages/boilerplate/theme/nuxt.config.js
@@ -101,8 +101,8 @@ export default {
   build: {
     babel: {
       plugins: [
-        ['@babel/plugin-proposal-private-methods', { loose: true }],
-      ],
+        ['@babel/plugin-proposal-private-methods', { loose: true }]
+      ]
     },
     transpile: [
       'vee-validate/dist/rules'

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -137,6 +137,11 @@ export default {
     scss: [require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] })]
   },
   build: {
+    babel: {
+      plugins: [
+        ['@babel/plugin-proposal-private-methods', { loose: true }]
+      ]
+    },
     transpile: [
       'vee-validate/dist/rules'
     ],

--- a/packages/core/docs/changelog/6123.js
+++ b/packages/core/docs/changelog/6123.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fixed Nuxt-CLI spamming babel warning due plugin configuration',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6123',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Heitor Ramon Ribeiro',
+  linkToGitHubAccount: 'https://github.com/bloodf'
+};


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes (EN-229)[https://vsf.atlassian.net/browse/EN-229]

### Short Description of the PR
removed the Nuxt-CLI warning about the @babel preset configuration on each run

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [x] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


