### PR TITLE
En 392 inventory mode for orders

### DIFF
--- a/packages/commercetools/api-client/src/api/createCart/index.ts
+++ b/packages/commercetools/api-client/src/api/createCart/index.ts
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import { CustomQuery } from '@vue-storefront/core';
 
 const createCart = async (context, cartDraft: CartData = {}, customQuery?: CustomQuery) => {
-  const { locale, acceptLanguage, currency, country } = context.config;
+  const { locale, acceptLanguage, currency, country, inventoryMode } = context.config;
 
   const defaultVariables = {
     acceptLanguage,
@@ -13,6 +13,7 @@ const createCart = async (context, cartDraft: CartData = {}, customQuery?: Custo
     draft: {
       currency,
       country,
+      inventoryMode,
       ...cartDraft
     }
   };

--- a/packages/commercetools/api-client/src/fragments/cart.ts
+++ b/packages/commercetools/api-client/src/fragments/cart.ts
@@ -76,5 +76,6 @@ export const CartFragment = `
     }
     cartState
     version
+    inventoryMode
   }
 `;

--- a/packages/commercetools/theme/middleware.config.js
+++ b/packages/commercetools/theme/middleware.config.js
@@ -15,8 +15,7 @@ module.exports = {
           ]
         },
         currency: 'USD',
-        country: 'US',
-        inventoryMode: 'None'
+        country: 'US'
       }
     }
   }

--- a/packages/commercetools/theme/middleware.config.js
+++ b/packages/commercetools/theme/middleware.config.js
@@ -1,3 +1,4 @@
+
 module.exports = {
   integrations: {
     ct: {
@@ -14,7 +15,8 @@ module.exports = {
           ]
         },
         currency: 'USD',
-        country: 'US'
+        country: 'US',
+        inventoryMode: 'None'
       }
     }
   }

--- a/packages/commercetools/theme/pages/Checkout/Payment.vue
+++ b/packages/commercetools/theme/pages/Checkout/Payment.vue
@@ -152,12 +152,13 @@ import {
   SfLink,
   SfInput
 } from '@storefront-ui/vue';
-import { ref, computed } from '@vue/composition-api';
+import { ref, computed, watch } from '@vue/composition-api';
 import { useMakeOrder, useCart, useBilling, useShipping, useShippingProvider, cartGetters } from '@vue-storefront/commercetools';
 import { onSSR } from '@vue-storefront/core';
 import getShippingMethodPrice from '@/helpers/Checkout/getShippingMethodPrice';
 import VsfPaymentProviderMock from '@/components/Checkout/VsfPaymentProviderMock';
 import { usePaymentProviderMock } from '@/composables/usePaymentProviderMock';
+import { useUiNotification } from '~/composables';
 
 export default {
   name: 'ReviewOrder',
@@ -185,7 +186,8 @@ export default {
     const billingSameAsShipping = computed(() => Object.keys(shippingDetails.value).every(shippingDetailsKey => shippingDetails.value[shippingDetailsKey] === billingDetails.value[shippingDetailsKey]));
     const products = computed(() => cartGetters.getItems(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
-    const { order, make, loading } = useMakeOrder();
+    const { order, make, loading, error } = useMakeOrder();
+    const { send } = useUiNotification();
 
     const terms = ref(false);
     const promoCode = ref('');
@@ -199,9 +201,18 @@ export default {
 
     const processOrder = async () => {
       await make();
+
+      if (error.value.make) return;
+
       context.root.$router.push(`/checkout/thank-you?order=${order.value.id}`);
       setCart(null);
     };
+
+    watch(() => ({...error.value}), (error, prevError) => {
+      if (error.make !== prevError.make)
+        send({ type: 'danger', message: error.make.message });
+    });
+
     return {
       loading,
       products,

--- a/packages/core/docs/commercetools/configuration.md
+++ b/packages/core/docs/commercetools/configuration.md
@@ -66,7 +66,7 @@ module.exports = {
     ct: {
       location: '@vue-storefront/commercetools-api/server',
       configuration: {
-        api: { /* ... */}
+        api: { /* ... */},
         currency: 'EUR',
         locale: 'en',
         country: 'US'
@@ -74,6 +74,7 @@ module.exports = {
     }
   }
 };
+```
 
 
 ### `acceptLanguage`
@@ -86,11 +87,19 @@ acceptLanguage: ['en-gb', 'en-us']
 
 ### `languageMap`
 
-If you supply a `languageMap` during setup this will be used to map a locale to the accepted languages.
+If you supply a `languageMap` during the setup, this will be used to map a locale to the accepted languages.
 
 ```js
 languageMap: {
   'en-gb': ['en-gb', 'en-us'],
   'en-us': ['en-us', 'en-gb'],
 }
+```
+
+### `inventoryMode`
+
+If you want to change the way your commercetools inventory is being tracked, you can provide `inventoryMode` option in the middleware configuration. It can be set to one of the following values: `None`, `TrackOnly`, and `ReserveOnOrder`. When not specified, the Inventory Mode is set to `None` by default. You can read more about Inventory Modes in [commercetools documentation](https://docs.commercetools.com/api/projects/carts#inventorymode).
+
+```js
+inventoryMode: 'TrackOnly'
 ```


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes EN-392

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Adds inventoryMode variable to `createCart` commercetools API.
Displays notification on failed order placement.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

![screencast-localhost_3000-2021 08 05-19_53_13 (3)](https://user-images.githubusercontent.com/26794636/128398129-b151f184-dac4-4296-95e3-2d7b8d9ec7df.gif)


### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


