### PR TITLE
fix: MyAccount page rendering

### DIFF
--- a/packages/core/docs/changelog/6171.js
+++ b/packages/core/docs/changelog/6171.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fixed MyAccount page rendering',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6172',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Łukasz Jędrasik',
+  linkToGitHubAccount: 'https://github.com/lukaszjedrasik'
+};

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -98,7 +98,7 @@
 import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay } from '@storefront-ui/vue';
 import { useUiState } from '~/composables';
 import { useCart, useUser, cartGetters } from '<%= options.generate.replace.composables %>';
-import { computed, ref, onBeforeUnmount, watch } from '@vue/composition-api';
+import { computed, ref, onBeforeUnmount, watch, onMounted } from '@vue/composition-api';
 import { useUiHelpers } from '~/composables';
 import LocaleSelector from './LocaleSelector';
 import SearchResults from '~/components/SearchResults';
@@ -134,6 +134,7 @@ export default {
     const isSearchOpen = ref(false);
     const searchBarRef = ref(null);
     const result = ref(null);
+    const isMobile = ref(false);
 
     const cartTotalItems = computed(() => {
       const count = cartGetters.getTotalItems(cart.value);
@@ -170,7 +171,9 @@ export default {
 
     }, 1000);
 
-    const isMobile = computed(() => mapMobileObserver().isMobile.get());
+    onMounted(() => {
+      isMobile.value = mapMobileObserver().isMobile.get();
+    });
 
     const closeOrFocusSearchBar = () => {
       if (isMobile.value) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #6171 

### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Fixed MyAccount page rendering

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
### Before
![Zrzut ekranu 2021-08-6 o 14 51 12](https://user-images.githubusercontent.com/40273258/128513116-eb07dd90-9c8e-423b-a414-75318be88d27.png)

### After
![Zrzut ekranu 2021-08-6 o 14 50 49](https://user-images.githubusercontent.com/40273258/128513066-67ecda42-51a9-4cbd-b417-3fd0f924ec0b.png)


### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


