### PR TITLE
Remove mode: 'universal' from the nuxt config

### DIFF
--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -3,7 +3,6 @@ import { VSF_LOCALE_COOKIE } from '@vue-storefront/core';
 import theme from './themeConfig';
 
 export default {
-  mode: 'universal',
   server: {
     port: 3000,
     host: '0.0.0.0'

--- a/packages/core/cli/__tests__/scripts/createProject/processMagicComments.spec.ts
+++ b/packages/core/cli/__tests__/scripts/createProject/processMagicComments.spec.ts
@@ -7,7 +7,6 @@ import { config } from './plugins/commercetools-config.js';
 const localeNames = config.locales.map(l => ({ code: l.name, file: 'abc.js', iso: l.name }));
 
 export default {
-  mode: 'universal',
   server: {
     port: 3000,
     host: '0.0.0.0'
@@ -122,7 +121,6 @@ import { config } from './plugins/commercetools-config.js';
 const localeNames = config.locales.map(l => ({ code: l.name, file: 'abc.js', iso: l.name }));
 
 export default {
-  mode: 'universal',
   server: {
     port: 3000,
     host: '0.0.0.0'


### PR DESCRIPTION
### Short Description of the PR
Removing `mode: 'universal'` from  `nuxt.config.js` since it's deprecated.
Read more https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-mode

Logs: 
![image](https://user-images.githubusercontent.com/10283686/129334165-bd8523ba-a06b-47e1-9968-85c3065bb350.png)

`yarn test:cli`
![image](https://user-images.githubusercontent.com/10283686/129334978-3c7c131c-c921-4651-8529-1454bc8ed14d.png)




Hi! Thank you all for building this amazing solution. I'd like some guidance on the pull request checklist. 

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Pull Request Checklist
<!-- we will not merge your Pull Request until all checkboxes are checked -->
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
<!-- VSF 1 only -->
- I tested manually my code and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme
- [ ] I have written test cases for my code
<!-- VSF Next only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

<!-- Please get familiar with following contribution tules https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md -->


