### PR TITLE
[EN-404] FIX: Products cannot be added to wishlist for logged-in customer

### DIFF
--- a/packages/core/nuxt-theme-module/theme/components/LoginModal.vue
+++ b/packages/core/nuxt-theme-module/theme/components/LoginModal.vue
@@ -199,7 +199,7 @@ import { ref, watch, reactive, computed } from '@vue/composition-api';
 import { SfModal, SfInput, SfButton, SfCheckbox, SfLoader, SfAlert, SfBar } from '@storefront-ui/vue';
 import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
 import { required, email } from 'vee-validate/dist/rules';
-import { useUser, useForgotPassword } from '<%= options.generate.replace.composables %>';
+import { useUser, useForgotPassword, useWishlist } from '<%= options.generate.replace.composables %>';
 import { useUiState } from '~/composables';
 
 extend('email', {
@@ -236,6 +236,7 @@ export default {
     const rememberMe = ref(false);
     const { register, login, loading, error: userError } = useUser();
     const { request, error: forgotPasswordError, loading: forgotPasswordLoading } = useForgotPassword();
+    const { load: loadWishlist } = useWishlist();
 
     const error = reactive({
       login: null,
@@ -285,6 +286,7 @@ export default {
         error.register = userError.value.register?.message;
         return;
       }
+      loadWishlist();
       toggleLoginModal();
     };
 

--- a/packages/core/nuxt-theme-module/theme/pages/MyAccount.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/MyAccount.vue
@@ -50,7 +50,7 @@
 <script>
 import { SfBreadcrumbs, SfContentPages } from '@storefront-ui/vue';
 import { computed, onBeforeUnmount } from '@vue/composition-api';
-import { useUser } from '<%= options.generate.replace.composables %>';
+import { useUser, useWishlist } from '<%= options.generate.replace.composables %>';
 import MyProfile from './MyAccount/MyProfile';
 import ShippingDetails from './MyAccount/ShippingDetails';
 import BillingDetails from './MyAccount/BillingDetails';
@@ -82,6 +82,7 @@ export default {
   setup(props, context) {
     const { $router, $route } = context.root;
     const { logout } = useUser();
+    const { setWishlist } = useWishlist();
     const isMobile = computed(() => mapMobileObserver().isMobile.get());
     const activePage = computed(() => {
       const { pageName } = $route.params;
@@ -98,6 +99,7 @@ export default {
     const changeActivePage = async (title) => {
       if (title === 'Log out') {
         await logout();
+        setWishlist(null);
         $router.push(context.root.localePath({ name: 'home' }));
         return;
       }


### PR DESCRIPTION
### Related Issues
closes [EN-404](https://vsf.atlassian.net/browse/EN-404)

### Short Description of the PR
We're dealing with these problems: 
- if I have a guest wishlist and then log in, I can not add anything to the wishlist after that (GraphQL error: Version mismatch. Concurrent modification)
- user wishlist is not loaded right after log in. It is only loaded after adding another product to it or reloading the page
- user wishlist is not cleared after log out

The key here is to implement wishlist `loading` on login and `clearing` on logout. Adding these to the authentication flow gets rid of the aforementioned problems. The solution I provide is a quick, 5-minute one. Works fine but I don't believe it is optimal. As suggested by @Baroshem, we should create a separate `useUser` composable in our enterprise-packages which handles it instead.