### PR TITLE
Add methods to api-reference (ct)

### DIFF
--- a/packages/commercetools/api-client/api-extractor.json
+++ b/packages/commercetools/api-client/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../api-extractor.base.json",
-  "mainEntryPointFilePath": "./lib/index.d.ts",
+  "mainEntryPointFilePath": "./lib/api-extractor-data.d.ts",
   "dtsRollup": {
     "untrimmedFilePath": "./lib/<unscopedPackageName>.d.ts"
   },

--- a/packages/commercetools/api-client/src/api-extractor-data.ts
+++ b/packages/commercetools/api-client/src/api-extractor-data.ts
@@ -1,0 +1,4 @@
+import * as apiMethods from './api';
+
+export * from './index';
+export { apiMethods };

--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -1,5 +1,6 @@
 import * as cartActions from './helpers/cart/actions';
 
+export * from './api';
 export * from './fragments';
 export * from './types/Api';
 export * from './types/GraphQL';

--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -1,6 +1,5 @@
 import * as cartActions from './helpers/cart/actions';
 
-export * from './api';
 export * from './fragments';
 export * from './types/Api';
 export * from './types/GraphQL';


### PR DESCRIPTION
closes [DOCS-58](https://vsf.atlassian.net/browse/DOCS-58)
### Short Description of the PR
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Unfortunately we can only have one `api-extractor.json` file in one package. So, I created an `api-extractor-data.ts` file that contains all the required data for building API reference.

![Zrzut ekranu 2021-08-23 o 08 09 36](https://user-images.githubusercontent.com/40273258/130398708-fe3d0bb2-4e1b-4cc0-9133-2b527f4ff224.png)

