### PR TITLE
test(os-158): add e2e tests for category page accordion

### DIFF
--- a/packages/commercetools/theme/tests/e2e/cypress.json
+++ b/packages/commercetools/theme/tests/e2e/cypress.json
@@ -7,15 +7,16 @@
   "viewportHeight": 1080,
   "viewportWidth": 1920,
   "pageLoadTimeout": 180000,
+  "defaultCommandTimeout": 10000,
   "screenshotOnRunFailure": true,
   "screenshotsFolder": "tests/e2e/report/assets/screenshots",
   "video": false,
   "reporter": "../../../../node_modules/mochawesome",
   "reporterOptions": {
-      "reportDir": "tests/e2e/report",
-      "reportFilename": "report",
-      "overwrite": false,
-      "html": false
+    "reportDir": "tests/e2e/report",
+    "reportFilename": "report",
+    "overwrite": false,
+    "html": false
   },
   "retries": {
     "runMode": 2,

--- a/packages/commercetools/theme/tests/e2e/fixtures/test-data/e2e-category-accordion.json
+++ b/packages/commercetools/theme/tests/e2e/fixtures/test-data/e2e-category-accordion.json
@@ -1,0 +1,76 @@
+{
+  "Should successfully show category accordion list": {
+    "header": {
+      "category": "men"
+    }
+  },
+  "Should successfully exists category items": {
+    "header": {
+      "category": "women"
+    },
+    "categories": [
+      {
+        "name": "Clothing"
+      },
+      {
+        "name": "Shoes"
+      },
+      {
+        "name": "Bags"
+      },
+      {
+        "name": "Looks"
+      }
+    ]
+  },
+  "Should successfully open subcategories for items": {
+    "header": {
+      "category": "men"
+    },
+    "categories": [
+      {
+        "name": "Clothing",
+        "subCategories": [
+          "All",
+          "Jackets",
+          "Tops",
+          "Shirts",
+          "Trousers",
+          "Jeans",
+          "Blazer",
+          "Suits",
+          "T-shirts"
+        ]
+      },
+      {
+        "name": "Shoes",
+        "subCategories": [
+          "All",
+          "Sneakers",
+          "Boots",
+          "Lace-up shoes",
+          "Loafers",
+          "Sandals"
+        ]
+      },
+      {
+        "name": "Bags",
+        "subCategories": [
+          "All",
+          "Clutches",
+          "Shoulder bags",
+          "Shopper",
+          "Handbag",
+          "Wallets",
+          "Bucketbag & packbag"
+        ]
+      },
+      {
+        "name": "Looks",
+        "subCategories": [
+          "All"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/commercetools/theme/tests/e2e/fixtures/test-data/e2e-category-accordion.json
+++ b/packages/commercetools/theme/tests/e2e/fixtures/test-data/e2e-category-accordion.json
@@ -4,7 +4,7 @@
       "category": "men"
     }
   },
-  "Should successfully exists category items": {
+  "Should successfully display category items": {
     "header": {
       "category": "women"
     },

--- a/packages/commercetools/theme/tests/e2e/integration/e2e-category-accordion.spec.ts
+++ b/packages/commercetools/theme/tests/e2e/integration/e2e-category-accordion.spec.ts
@@ -1,0 +1,42 @@
+import page from '../pages/factory';
+
+context('Category page accordion', () => {
+  beforeEach(function () {
+    cy.fixture('test-data/e2e-category-accordion').then((fixture) => {
+      this.fixtures = {
+        data: fixture
+      };
+    });
+  });
+
+  it('Should successfully show category accordion list', function () {
+    const data = this.fixtures.data[this.test.title];
+    const category = page.category(data.header.category);
+    category.visit();
+    page.components.categoryAccordion.container.should('be.visible');
+  });
+
+  it('Should successfully exists category items', function () {
+    const data = this.fixtures.data[this.test.title];
+    const category = page.category(data.header.category);
+    category.visit();
+    data.categories.forEach(category => {
+      page.components.categoryAccordion.category(category.name).should('be.visible');
+    });
+  });
+
+  it('Should successfully open subcategories for items', function () {
+    const data = this.fixtures.data[this.test.title];
+    const category = page.category(data.header.category);
+    category.visit();
+    page.components.categoryAccordion.categories.first().click();
+    data.categories.forEach(category => {
+      page.components.categoryAccordion.category(category.name).click().then(() => {
+        cy.wait(2000);
+        category.subCategories.forEach(subCategory => {
+          page.components.categoryAccordion.subCategoryName(subCategory).should('be.visible');
+        });
+      });
+    });
+  });
+});

--- a/packages/commercetools/theme/tests/e2e/integration/e2e-category-accordion.spec.ts
+++ b/packages/commercetools/theme/tests/e2e/integration/e2e-category-accordion.spec.ts
@@ -1,6 +1,6 @@
 import page from '../pages/factory';
 
-context('Category page accordion', () => {
+context(['regression'], 'Category page accordion', () => {
   beforeEach(function () {
     cy.fixture('test-data/e2e-category-accordion').then((fixture) => {
       this.fixtures = {
@@ -16,7 +16,7 @@ context('Category page accordion', () => {
     page.components.categoryAccordion.container.should('be.visible');
   });
 
-  it('Should successfully exists category items', function () {
+  it('Should successfully display category items', function () {
     const data = this.fixtures.data[this.test.title];
     const category = page.category(data.header.category);
     category.visit();
@@ -32,7 +32,6 @@ context('Category page accordion', () => {
     page.components.categoryAccordion.categories.first().click();
     data.categories.forEach(category => {
       page.components.categoryAccordion.category(category.name).click().then(() => {
-        cy.wait(2000);
         category.subCategories.forEach(subCategory => {
           page.components.categoryAccordion.subCategoryName(subCategory).should('be.visible');
         });

--- a/packages/commercetools/theme/tests/e2e/pages/components/category-accordion.ts
+++ b/packages/commercetools/theme/tests/e2e/pages/components/category-accordion.ts
@@ -1,0 +1,21 @@
+import { el } from '../utils/element';
+
+class CategoryAccordion {
+  get container(): Cypress.Chainable {
+    return el('categories-accordion');
+  }
+  get categories(): Cypress.Chainable {
+    return el('categories-accordion', 'button');
+  }
+  category(name: string): Cypress.Chainable {
+    return this.categories.contains(name);
+  }
+  subCategories(): Cypress.Chainable {
+    return el('categories-accordion', '.sf-accordion-item__content ul li').find('a');
+  }
+  subCategoryName(subCategoryName?: string): Cypress.Chainable {
+    return this.subCategories().contains(subCategoryName);
+  }
+}
+
+export default new CategoryAccordion();

--- a/packages/commercetools/theme/tests/e2e/pages/components/category-accordion.ts
+++ b/packages/commercetools/theme/tests/e2e/pages/components/category-accordion.ts
@@ -13,7 +13,7 @@ class CategoryAccordion {
   subCategories(): Cypress.Chainable {
     return el('categories-accordion', '.sf-accordion-item__content ul li').find('a');
   }
-  subCategoryName(subCategoryName?: string): Cypress.Chainable {
+  subCategoryName(subCategoryName: string): Cypress.Chainable {
     return this.subCategories().contains(subCategoryName);
   }
 }

--- a/packages/commercetools/theme/tests/e2e/pages/factory.ts
+++ b/packages/commercetools/theme/tests/e2e/pages/factory.ts
@@ -6,6 +6,7 @@ import Home from './home';
 import { MyProfile, OrderHistory } from './my-account';
 import { Product } from './product';
 import { Category } from './category';
+import CategoryAccordion from './components/category-accordion';
 
 const page = {
   get checkout() {
@@ -21,7 +22,8 @@ const page = {
     return {
       cart: Cart,
       loginModal: LoginModal,
-      breadcrumbs: Breadcrumbs
+      breadcrumbs: Breadcrumbs,
+      categoryAccordion: CategoryAccordion
     };
   },
 

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -93,6 +93,7 @@
           :class="{ 'loading--categories': loading }"
           :loading="loading">
             <SfAccordion
+              v-e2e="'categories-accordion'"
               :open="activeCategory"
               :show-chevron="true"
             >


### PR DESCRIPTION
## Description
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Added missing e2e tests  for category page accordion.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- For example closes #123  -->
<!--- Please link to the issue here: -->
Closes #6254

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Automatic e2e tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [x] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

