### PR TITLE
[commercetools] Add server-specific API client

### DIFF
--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/authHelpers.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/authHelpers.ts
@@ -1,7 +1,6 @@
 import SdkAuth, { TokenProvider } from '@commercetools/sdk-auth';
-import { Logger } from '@vue-storefront/core';
 import { Config, ApiConfig } from '../../types/setup';
-import { isAnonymousSession, isUserSession, getAccessToken } from '../utils';
+import { isAnonymousSession, isUserSession } from '../utils';
 import fetch from 'isomorphic-fetch';
 
 export const createAuthClient = (config: ApiConfig): SdkAuth => {
@@ -25,13 +24,8 @@ export const createTokenProvider = (settings: Config, {
   return new TokenProvider({
     sdkAuth,
     fetchTokenInfo: (sdkAuthInstance) => sdkAuthInstance.clientCredentialsFlow(),
-    onTokenInfoChanged: (tokenInfo) => {
-      Logger.debug('TokenProvider.onTokenInfoChanged', getAccessToken(tokenInfo));
-      settings.auth.onTokenChange(tokenInfo);
-    },
-    onTokenInfoRefreshed: (tokenInfo) => {
-      Logger.debug('TokenProvider.onTokenInfoRefreshed', getAccessToken(tokenInfo));
-    }
+    onTokenInfoChanged: (tokenInfo) => settings.auth.onTokenChange(tokenInfo),
+    onTokenInfoRefreshed: (tokenInfo) => settings.auth.onTokenChange(tokenInfo)
   }, currentToken);
 };
 

--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/createCommerceToolsConnection.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/createCommerceToolsConnection.ts
@@ -50,7 +50,7 @@ export const createCommerceToolsConnection = (settings: Config): any => {
   });
 
   const errorRetry = new RetryLink({
-    attempts: handleRetry({ tokenProvider }),
+    attempts: handleRetry({ settings, tokenProvider }),
     delay: () => 0
   });
 

--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/createCommerceToolsConnection.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/createCommerceToolsConnection.ts
@@ -1,6 +1,5 @@
 import { Config } from '../../types/setup';
 import { Logger } from '@vue-storefront/core';
-import { getAccessToken } from '../utils';
 import { createHttpLink } from 'apollo-link-http';
 import { createErrorHandler } from './graphqlError';
 import { setContext } from 'apollo-link-context';
@@ -12,8 +11,6 @@ import { createAuthClient, createTokenProvider } from './authHelpers';
 
 export const createCommerceToolsConnection = (settings: Config): any => {
   let currentToken: any = settings.auth.onTokenRead();
-  Logger.debug('createCommerceToolsConnection', getAccessToken(currentToken));
-
   const sdkAuth = createAuthClient(settings.api);
   const tokenProvider = createTokenProvider(settings, { sdkAuth, currentToken });
   const httpLink = createHttpLink({ uri: settings.api.uri, fetch });
@@ -21,8 +18,14 @@ export const createCommerceToolsConnection = (settings: Config): any => {
 
   const authLinkBefore = setContext(async (apolloReq, { headers }) => {
     Logger.debug('Apollo authLinkBefore', apolloReq.operationName);
-    currentToken = await handleBeforeAuth({ sdkAuth, tokenProvider, apolloReq, currentToken });
-    Logger.debug('Apollo authLinkBefore, finished, generated token: ', getAccessToken(currentToken));
+
+    currentToken = await handleBeforeAuth({
+      settings,
+      sdkAuth,
+      tokenProvider,
+      apolloReq,
+      currentToken
+    });
 
     return {
       headers: {
@@ -51,7 +54,12 @@ export const createCommerceToolsConnection = (settings: Config): any => {
     delay: () => 0
   });
 
-  const apolloLink = ApolloLink.from([onErrorLink, errorRetry, authLinkBefore, authLinkAfter.concat(httpLink)]);
+  const apolloLink = ApolloLink.from([
+    onErrorLink,
+    errorRetry,
+    authLinkBefore,
+    authLinkAfter.concat(httpLink)
+  ]);
 
   return {
     apolloLink,

--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
@@ -100,9 +100,9 @@ export const handleBeforeAuth = async ({
 };
 
 /**
- * The handler that generates an access token for the user if all three requirements are met:
- *  - customer is not already logged in;
- *  - customer performed one of the user-specific operations;
+ * The handler that generates an access token for the user if all three conditions are met:
+ *  - the customer is not already logged in;
+ *  - the customer performed one of the user-specific operations;
  *  - response from the commercetools doesn't contain any errors, meaning that the given credentials are valid;
  */
 export const handleAfterAuth = async ({ sdkAuth, tokenProvider, apolloReq, currentToken, response }) => {

--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
@@ -1,44 +1,125 @@
 import { Logger } from '@vue-storefront/core';
-import { isAnonymousSession, isUserSession, getAccessToken } from '../utils';
-import { isAnonymousOperation, isUserOperation } from './restrictedOperations';
+import { isAnonymousSession, isUserSession } from '../utils';
+import { isServerOperation, isAnonymousOperation, isUserOperation } from './restrictedOperations';
 
-export const handleBeforeAuth = async ({ sdkAuth, tokenProvider, apolloReq, currentToken }) => {
+/**
+ * Returns access token for the Server Middleware. It usually has more permissions than anonymous / user access token.
+ *
+ * If the configuration doesn't specify server-specific API client configuration, it will fallback to customer access tokens configuration.
+ */
+async function generateServerAccessToken({
+  settings,
+  apolloReq,
+  sdkAuth
+}): Promise<string> {
+  Logger.debug(`Generating server access token for operation "${ apolloReq.operationName }"`);
+
+  const { clientId, clientSecret, scopes } = settings.serverApi || settings.api;
+
+  const token = await sdkAuth.clientCredentialsFlow({
+    credentials: {
+      clientId,
+      clientSecret
+    },
+    scopes
+  });
+
+  Logger.debug(`Successfully generated server access token for operation "${ apolloReq.operationName }"`);
+
+  return token;
+}
+
+/**
+ * Returns access token for the anonymous session.
+ */
+async function generateAnonymousAccessToken({
+  apolloReq,
+  sdkAuth,
+  tokenProvider
+}): Promise<string> {
+  Logger.debug(`Generating anonymous access token for operation "${ apolloReq.operationName }"`);
+
+  const token = await sdkAuth.anonymousFlow();
+  tokenProvider.setTokenInfo(token);
+
+  Logger.debug(`Successfully generated anonymous access token for operation "${ apolloReq.operationName }"`);
+
+  return token;
+}
+
+/**
+ * Returns access token for the logged in customer.
+ */
+async function generateUserAccessToken({
+  apolloReq,
+  sdkAuth,
+  tokenProvider
+}): Promise<string> {
+  Logger.debug(`Generating user access token for operation "${ apolloReq.operationName }"`);
+
+  const { email, password } = apolloReq.variables.draft;
+  const token = await sdkAuth.customerPasswordFlow({ username: email, password });
+  tokenProvider.setTokenInfo(token);
+
+  Logger.debug(`Successfully generated user access token for operation "${ apolloReq.operationName }"`);
+
+  return token;
+}
+
+/**
+ * The handler that checks if it's necessary to generate a server or anonymous access token.
+ */
+export const handleBeforeAuth = async ({
+  settings,
+  sdkAuth,
+  tokenProvider,
+  apolloReq,
+  currentToken
+}) => {
   const isAnonymous = isAnonymousSession(currentToken);
   const isUser = isUserSession(currentToken);
   const isGuest = !isAnonymous && !isUser;
 
+  if (isServerOperation(apolloReq.operationName)) {
+    return await generateServerAccessToken({
+      settings,
+      apolloReq,
+      sdkAuth
+    });
+  }
+
   if (isGuest && isAnonymousOperation(apolloReq.operationName)) {
-    Logger.debug('Apollo authLinkBefore, anonymousFlow', apolloReq.operationName);
-
-    const token = await sdkAuth.anonymousFlow();
-    tokenProvider.setTokenInfo(token);
-    Logger.debug('Apollo authLinkBefore, anonymousFlow, generated token: ', getAccessToken(token));
-
-    return token;
+    return await generateAnonymousAccessToken({
+      apolloReq,
+      sdkAuth,
+      tokenProvider
+    });
   }
 
   return tokenProvider.getTokenInfo();
 };
 
+/**
+ * The handler that generates an access token for the user if all three requirements are met:
+ *  - customer is not already logged in;
+ *  - customer performed one of the user-specific operations;
+ *  - response from the commercetools doesn't contain any errors, meaning that the given credentials are valid;
+ */
 export const handleAfterAuth = async ({ sdkAuth, tokenProvider, apolloReq, currentToken, response }) => {
-  if (!isUserSession(currentToken) && isUserOperation(apolloReq.operationName)) {
-    const { email, password } = apolloReq.variables.draft;
-    Logger.debug('Apollo authLinkAfter, customerPasswordFlow', apolloReq.operationName);
-
-    if (!response.errors?.length) {
-      const token = await sdkAuth.customerPasswordFlow({ username: email, password });
-      tokenProvider.setTokenInfo(token);
-      Logger.debug('Apollo authLinkAfter, customerPasswordFlow, generated token: ', getAccessToken(token));
-
-      return token;
-    }
-
-    return currentToken;
+  if (!isUserSession(currentToken) && isUserOperation(apolloReq.operationName) && !response.errors?.length) {
+    return generateUserAccessToken({
+      apolloReq,
+      sdkAuth,
+      tokenProvider
+    });
   }
 
   return currentToken;
 };
 
+/**
+ * The handler that retries requests to the commercetools server if specific conditions are met.
+ */
 export const handleRetry = ({ tokenProvider }) => (count, operation, error) => {
   if (count > 3) {
     return false;

--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/restrictedOperations.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/restrictedOperations.ts
@@ -1,5 +1,10 @@
 /* istanbul ignore file */
 const restrictedOperations = {
+  server: [
+    'customerCreatePasswordResetToken',
+    'createReview',
+    'reviews'
+  ],
   anonymous: [
     'createCart',
     'createMyShoppingList'
@@ -10,5 +15,14 @@ const restrictedOperations = {
   ]
 };
 
-export const isAnonymousOperation = (operationName) => restrictedOperations.anonymous.includes(operationName);
-export const isUserOperation = (operationName) => restrictedOperations.user.includes(operationName);
+export function isServerOperation(operationName: string): boolean {
+  return restrictedOperations.server.includes(operationName);
+}
+
+export function isAnonymousOperation(operationName: string): boolean {
+  return restrictedOperations.anonymous.includes(operationName);
+}
+
+export function isUserOperation(operationName: string): boolean {
+  return restrictedOperations.user.includes(operationName);
+}

--- a/packages/commercetools/api-client/src/helpers/utils.ts
+++ b/packages/commercetools/api-client/src/helpers/utils.ts
@@ -1,6 +1,5 @@
 export const isAnonymousSession = (token) => token?.scope?.includes('anonymous_id');
 export const isUserSession = (token) => token?.scope?.includes('customer_id');
-export const getAccessToken = (token) => token ? token.access_token : null;
 export const getStoreKey = (store: string | undefined) => store
   ? ({ storeKey: store?.split('/')[0] })
   : {};

--- a/packages/commercetools/api-client/src/index.server.ts
+++ b/packages/commercetools/api-client/src/index.server.ts
@@ -2,7 +2,7 @@
 import ApolloClient from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import * as api from './api';
-import { Config, ClientInstance } from './types/setup';
+import { Config, ClientInstance, CT_COOKIE_NAME } from './types/setup';
 import { createCommerceToolsConnection } from './helpers/commercetoolsLink/createCommerceToolsConnection';
 import { defaultSettings } from './helpers/apiClient/defaultSettings';
 import { apiClientFactory, ApiClientExtension } from '@vue-storefront/core';
@@ -80,28 +80,15 @@ const tokenExtension: ApiClientExtension = {
         ...configuration,
         ...getI18nConfig(req, configuration),
         auth: {
-          onTokenChange: (newToken) => {
-            if (!currentToken || currentToken.access_token !== newToken.access_token) {
-              res.cookie(
-                'vsf-commercetools-token',
-                JSON.stringify(newToken),
-                newToken?.expires_at ? { expires: new Date(newToken.expires_at) } : {}
-              );
-            }
-          },
+          onTokenChange: (token) => res.cookie(
+            CT_COOKIE_NAME,
+            JSON.stringify(token),
+            token?.expires_at ? { expires: new Date(token.expires_at) } : {}
+          ),
 
-          onTokenRead: () => {
-            res.cookie(
-              'vsf-commercetools-token',
-              rawCurrentToken,
-              currentToken?.expires_at ? { expires: new Date(currentToken.expires_at) } : {}
-            );
-            return currentToken;
-          },
+          onTokenRead: () => currentToken,
 
-          onTokenRemove: () => {
-            delete req.cookies['vsf-commercetools-token'];
-          }
+          onTokenRemove: () => res.clearCookie(CT_COOKIE_NAME)
         }
       })
     };
@@ -112,18 +99,7 @@ const logMailExtension: ApiClientExtension = {
   name: 'logMailExtension',
   extendApiMethods: {
     customerCreatePasswordResetToken: async (context, email) => {
-      const response = await api.customerCreatePasswordResetToken(context, email);
-      const token = response?.data?.customerCreatePasswordResetToken?.value;
-
-      const emailObject = {
-        to: email,
-        from: 'password-recovery@vue-storefront.io',
-        subject: `Password recovery for ${email}`,
-        html: `<a href='/reset-password?token=${token}'>Reset your password by clicking this link</a>`
-      };
-
-      console.log(JSON.stringify(emailObject));
-      return response;
+      return await api.customerCreatePasswordResetToken(context, email);
     }
   }
 };

--- a/packages/commercetools/api-client/src/index.server.ts
+++ b/packages/commercetools/api-client/src/index.server.ts
@@ -99,7 +99,18 @@ const logMailExtension: ApiClientExtension = {
   name: 'logMailExtension',
   extendApiMethods: {
     customerCreatePasswordResetToken: async (context, email) => {
-      return await api.customerCreatePasswordResetToken(context, email);
+      const response = await api.customerCreatePasswordResetToken(context, email);
+      const token = response?.data?.customerCreatePasswordResetToken?.value;
+
+      const emailObject = {
+        to: email,
+        from: 'password-recovery@vue-storefront.io',
+        subject: `Password recovery for ${email}`,
+        html: `<a href='/reset-password?token=${token}'>Reset your password by clicking this link</a>`
+      };
+
+      console.log(JSON.stringify(emailObject));
+      return response;
     }
   }
 };

--- a/packages/commercetools/api-client/src/types/setup.ts
+++ b/packages/commercetools/api-client/src/types/setup.ts
@@ -78,6 +78,7 @@ export interface CustomerCredentials {
 export interface Config<T = any> {
   client?: ApolloClient<T>;
   api: ApiConfig;
+  serverApi?: Pick<ApiConfig, 'clientId' | 'clientSecret' | 'scopes'>;
   customOptions?: ApolloClientOptions<any>;
   currency: string;
   locale: string;

--- a/packages/commercetools/api-client/src/types/setup.ts
+++ b/packages/commercetools/api-client/src/types/setup.ts
@@ -2,6 +2,11 @@
 import SdkAuth, { TokenProvider } from '@commercetools/sdk-auth';
 import ApolloClient, { ApolloClientOptions } from 'apollo-client';
 
+/**
+ * Name of the cookie storing the commercetools access token.
+ */
+export const CT_COOKIE_NAME = 'vsf-commercetools-token';
+
 export interface ClientInstance extends ApolloClient<any> {
   sdkAuth?: SdkAuth;
   tokenProvider?: TokenProvider;

--- a/packages/commercetools/theme/middleware.config.js
+++ b/packages/commercetools/theme/middleware.config.js
@@ -8,6 +8,20 @@ module.exports = {
           uri: 'https://api.commercetools.com/vsf-ct-dev/graphql',
           authHost: 'https://auth.sphere.io',
           projectKey: 'vsf-ct-dev',
+          clientId: 'FGUpRp88xDpaDEDpVfbfs0Q-',
+          clientSecret: 'DvQvj3ccl-qwqS6qFnO-n0PUmjb8ok3G',
+          scopes: [
+            'create_anonymous_token:vsf-ct-dev',
+            'manage_my_profile:vsf-ct-dev',
+            'view_categories:vsf-ct-dev',
+            'manage_my_payments:vsf-ct-dev',
+            'manage_my_orders:vsf-ct-dev',
+            'manage_my_shopping_lists:vsf-ct-dev',
+            'view_published_products:vsf-ct-dev',
+            'view_stores:vsf-ct-dev'
+          ]
+        },
+        serverApi: {
           clientId: 'kuFT95wdTP4uH_hVOKjqfGEo',
           clientSecret: 'tklIDic86mgWrFy0oBHRQQmwX7ZC5wIP',
           scopes: [

--- a/packages/core/docs/commercetools/changelog/6321.js
+++ b/packages/core/docs/commercetools/changelog/6321.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Add server-specific API client',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6321',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};

--- a/packages/core/docs/commercetools/getting-started.md
+++ b/packages/core/docs/commercetools/getting-started.md
@@ -27,6 +27,13 @@ Then paste these credentials into `ct` config object inside `integrations` in `m
             //* scopes */
           ]
         },
+        serverApi: {
+          clientId: '<CLIENT_ID>',
+          clientSecret: '<CLIENT_SECRET>',
+          scopes: [
+            //* scopes */
+          ]
+        },
         currency: 'USD',
         country: 'US'
       }


### PR DESCRIPTION
Some operations (like resetting user passwords or adding/viewing reviews) require management permissions, which regular users shouldn't have.

For this reason, we are adding a new `serverApi` key to the commercetools integration configuration that allows specifying credentials for generating the server-specific access tokens.

New `serverApi` inside of the commercetools integration configuration should contain three keys:
* `clientId: string`
* `clientSecret: string`
* `scopes: string[]`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.

#### Changelog
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [X] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

#### Code standards
- [X] My code follows the code style of this project.
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.

