### PR TITLE
6347 productType field on product object

### DIFF
--- a/packages/commercetools/composables/__tests__/helpers/enhanceProduct.spec.ts
+++ b/packages/commercetools/composables/__tests__/helpers/enhanceProduct.spec.ts
@@ -7,6 +7,9 @@ const attributesRaw = () => [
 ];
 
 const product = (name, slug, id) => ({
+  productType: {
+    name: 'type'
+  },
   masterData: {
     current: {
       name,

--- a/packages/commercetools/composables/src/helpers/internals/enhanceProduct.ts
+++ b/packages/commercetools/composables/src/helpers/internals/enhanceProduct.ts
@@ -37,7 +37,8 @@ const enhanceProduct = (productResponse: ApolloQueryResult<ProductData>, context
         _master: current.masterVariant.id === variant.id,
         _description: current.description,
         _categoriesRef: current.categoriesRef.map((cr) => cr.id),
-        _rating: (product as any).reviewRatingStatistics
+        _rating: (product as any).reviewRatingStatistics,
+        _type: product.productType?.name
       }));
     })
     .reduce((prev, curr) => [...prev, ...curr], []);

--- a/packages/core/docs/changelog/6347.js
+++ b/packages/core/docs/changelog/6347.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: "getProduct custom query - productType doesn't get mapped to product response in enhanceProduct helper",
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/6347',
+  isBreaking: false,
+  author: 'David Golodetsky',
+  linkToGitHubAccount: 'https://github.com/DavidGolodetsky',
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
getProduct custom query - productType field doesn't get mapped to product response in enhanceProduct helper

## Related Issue
closes #6347
https://github.com/vuestorefront/vue-storefront/issues/6347


## How Has This Been Tested?
Tested locally with an exiting project

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [x] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [x] I have added tests to cover my changes.
- [] All new and existing tests passed.

Haven't figured out how to update the test snapshot

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

