### PR TITLE
fix(cache): cache package invalidation bug

### DIFF
--- a/packages/core/cache/nuxt/index.js
+++ b/packages/core/cache/nuxt/index.js
@@ -28,17 +28,16 @@ function createInvalidationEndpoint (driver, options) {
         tags: Array.from(new Set(tags))
       });
 
-      response.status(200).send('Cache invalidated successfully!');
+      response
+        .status(200)
+        .send('Cache invalidated successfully!');
     } catch (error) {
       Logger.error('Cache driver thrown an error when invalidating cache! Operation skipped.');
       Logger.error(error);
 
       response
         .status(500)
-        .send(
-          'Cache driver thrown an error when invalidating cache! Operation skipped. ' +
-          error
-        );
+        .send(`Cache driver thrown an error when invalidating cache! Operation skipped. ${error}`);
     }
   };
 

--- a/packages/core/cache/nuxt/index.js
+++ b/packages/core/cache/nuxt/index.js
@@ -28,15 +28,18 @@ function createInvalidationEndpoint (driver, options) {
         tags: Array.from(new Set(tags))
       });
 
-      response.writeHead(200);
+      response.status(200).send('Cache invalidated successfully!');
     } catch (error) {
       Logger.error('Cache driver thrown an error when invalidating cache! Operation skipped.');
       Logger.error(error);
 
-      response.writeHead(500);
+      response
+        .status(500)
+        .send(
+          'Cache driver thrown an error when invalidating cache! Operation skipped. ' +
+          error
+        );
     }
-
-    response.end();
   };
 
   this.addServerMiddleware({

--- a/packages/core/docs/changelog/6353.js
+++ b/packages/core/docs/changelog/6353.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Cache package invalidation bug',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6353',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Łukasz Śliwa',
+  linkToGitHubAccount: 'https://github.com/lsliwaradioluz'
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Our cache package is behaving unexpectedly while hitting the `/cache-invalidate` endpoint. Instead of doing its job, it is resulting in the browser downloading an empty file named `cache-invalidate`.

It turns out the bug is occurring only if the `@nuxt/pwa` module is enabled. The service worker registered by it is unhappy with the `/cache-invalidate` endpoint handler using the `response.end()` method and is causing some internal redirect. The bug can be reproduced only in production. By production I mean an application deployed to the server since the bug cannot be reproduced after building our app locally (even though the service worker is registered there too).

To fix the bug, I've changed the previous handler logic so that it uses `response.status().send()` instead of `response.writeHead().end()`.

