### PR TITLE
Remove outdated information and fix changelog generation

### DIFF
--- a/packages/core/docs/advanced/logging.md
+++ b/packages/core/docs/advanced/logging.md
@@ -74,27 +74,3 @@ To override the default logger, pass a function to the `logger.customLogger` pro
   }
 ];
 ```
-
-::: details Configuring logger outside Vue Storefront Nuxt module
-If you can't configure logger through the `@vue-storefront/nuxt` module, you can explicitly use the `registerLogger` function:
-
-```ts
-import { registerLogger } from '@vue-storefront/core';
-
-const myLogger = {
-  debug: (message: any, ...args) =>
-    console.debug('[VSF][debug]', message, ...args),
-  info: (message: any, ...args) =>
-    console.info('[VSF][info]', message, ...args),
-  warn: (message: any, ...args) =>
-    console.warn('[VSF][warn]', message, ...args),
-  error: (message: any, ...args) =>
-    console.error('[VSF][error]', message, ...args)
-};
-
-const verbosity = 'error';
-
-registerLogger(myLogger, verbosity);
-```
-
-:::

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -6,7 +6,7 @@
 
   | Before | After | Comment | Module |
   | ------ | ----- | ------- | ------ |
-  | &amp;#x60;loadUser&amp;#x60; was called directly inside &amp;#x60;setup&amp;#x60; method in &amp;#x60;CartSidebar.vue&amp;#x60; component | &amp;#x60;loadUser&amp;#x60; is called inside &amp;#x60;onSSR&amp;#x60; callback in &amp;#x60;CartSidebar.vue&amp;#x60; component | Calling &amp;#x60;loadUser&amp;#x60; directly inside &amp;#x60;setup&amp;#x60; method caused hydration issues, since cart information was not properly loaded during SSR. Additionally cart will now be automatically updated after calling &amp;#x60;load&amp;#x60; from the &amp;#x60;useUser&amp;#x60; composable, the same way as it happens when calling &amp;#x60;logIn&amp;#x60;, &amp;#x60;logOut&amp;#x60; and &amp;#x60;register&amp;#x60;. | commercetools theme |
+  | `loadUser` was called directly inside `setup` method in `CartSidebar.vue` component | `loadUser` is called inside `onSSR` callback in `CartSidebar.vue` component | Calling `loadUser` directly inside `setup` method caused hydration issues, since cart information was not properly loaded during SSR. Additionally cart will now be automatically updated after calling `load` from the `useUser` composable, the same way as it happens when calling `logIn`, `logOut` and `register`. | commercetools theme |
 
 - Add server-specific API client ([6321](https://github.com/vuestorefront/vue-storefront/pull/6321)) - [Filip Sobol](https://github.com/filipsobol)
 

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -6,7 +6,7 @@
 
   | Before | After | Comment | Module |
   | ------ | ----- | ------- | ------ |
-  | &amp;#x60;loadCart&amp;#x60; was called directly inside &amp;#x60;setup&amp;#x60; method in &amp;#x60;CartSidebar.vue&amp;#x60; component | &amp;#x60;loadCart&amp;#x60; is called inside &amp;#x60;onSSR&amp;#x60; callback in &amp;#x60;CartSidebar.vue&amp;#x60; component | Calling &amp;#x60;loadCart&amp;#x60; directly inside &amp;#x60;setup&amp;#x60; method caused hydration issues, since cart information was not properly loaded during SSR | Base theme |
+  | `loadCart` was called directly inside `setup` method in `CartSidebar.vue` component | `loadCart` is called inside `onSSR` callback in `CartSidebar.vue` component | Calling `loadCart` directly inside `setup` method caused hydration issues, since cart information was not properly loaded during SSR | Base theme |
 
 ## 2.4.1
 

--- a/packages/core/docs/scripts/changelog.js
+++ b/packages/core/docs/scripts/changelog.js
@@ -25,7 +25,12 @@ const changes = fileName
   // eslint-disable-next-line global-require
   .map(el => require(`${pathIn}/${el}`))
   .map((pullRequest, index) => {
-    return compile(templates.change)({
+    const template = compile(
+      templates.change,
+      { noEscape: true }
+    );
+
+    return template({
       ...pullRequest,
       prNumber: pullRequestIds[index]
     });
@@ -41,10 +46,15 @@ const versionLineNumber = changelog
   .map(el => el.indexOf(version))
   .findIndex(el => el > -1);
 
+const template = compile(
+  templates.version,
+  { noEscape: true }
+);
+
 // Update changelog file
 versionLineNumber > -1
   ? changelog.splice(versionLineNumber + 2, 0, changes)
-  : changelog.splice(2, 0, compile(templates.version)({ version, changes }));
+  : changelog.splice(2, 0, template({ version, changes }));
 
 // Write updated changelog file
 writeFileSync(pathOut, changelog.join('\n'));

--- a/packages/core/docs/scripts/templates/version.hbs
+++ b/packages/core/docs/scripts/templates/version.hbs
@@ -1,3 +1,3 @@
-## {{ version }}
+## {{{ version }}}
 
-{{ changes }}
+{{{ changes }}}

--- a/packages/core/docs/scripts/templates/version.hbs
+++ b/packages/core/docs/scripts/templates/version.hbs
@@ -1,3 +1,3 @@
-## {{{ version }}}
+## {{ version }}
 
-{{{ changes }}}
+{{ changes }}


### PR DESCRIPTION
1. Remove outdated information from Logging doc
2. Fix changelog generation
3. Update changelog from the last release.