### PR TITLE
fix(commercetools): fix password reset and improve server api

### DIFF
--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/linkHandlers.ts
@@ -77,7 +77,7 @@ export const handleBeforeAuth = async ({
   currentToken
 }) => {
   const isGuest = !isAnonymousSession(currentToken) && !isUserSession(currentToken) && isAnonymousOperation(apolloReq.operationName);
-  const isServer = isServerOperation(apolloReq.operationName);
+  const isServer = isServerOperation(settings, apolloReq.operationName);
 
   const customToken = await settings.customToken?.({
     settings,

--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/restrictedOperations.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/restrictedOperations.ts
@@ -20,7 +20,7 @@ const restrictedOperations = {
 export function isServerOperation(settings: Config, operationName: string): boolean {
   const operations = [
     ...restrictedOperations.server,
-    ...(settings.serverApi.operations || [])
+    ...(settings?.serverApi?.operations || [])
   ];
 
   return operations.includes(operationName);

--- a/packages/commercetools/api-client/src/helpers/commercetoolsLink/restrictedOperations.ts
+++ b/packages/commercetools/api-client/src/helpers/commercetoolsLink/restrictedOperations.ts
@@ -1,6 +1,8 @@
-/* istanbul ignore file */
+import { Config } from '../../types/setup';
+
 const restrictedOperations = {
   server: [
+    'customerResetPassword',
     'customerCreatePasswordResetToken',
     'createReview',
     'reviews'
@@ -15,8 +17,13 @@ const restrictedOperations = {
   ]
 };
 
-export function isServerOperation(operationName: string): boolean {
-  return restrictedOperations.server.includes(operationName);
+export function isServerOperation(settings: Config, operationName: string): boolean {
+  const operations = [
+    ...restrictedOperations.server,
+    ...(settings.serverApi.operations || [])
+  ];
+
+  return operations.includes(operationName);
 }
 
 export function isAnonymousOperation(operationName: string): boolean {

--- a/packages/commercetools/api-client/src/types/setup.ts
+++ b/packages/commercetools/api-client/src/types/setup.ts
@@ -75,10 +75,14 @@ export interface CustomerCredentials {
   password: string;
 }
 
+export interface ServerApiConfiguration extends Pick<ApiConfig, 'clientId' | 'clientSecret' | 'scopes'> {
+  operations?: string[];
+}
+
 export interface Config<T = any> {
   client?: ApolloClient<T>;
   api: ApiConfig;
-  serverApi?: Pick<ApiConfig, 'clientId' | 'clientSecret' | 'scopes'>;
+  serverApi?: ServerApiConfiguration;
   customOptions?: ApolloClientOptions<any>;
   currency: string;
   locale: string;

--- a/packages/commercetools/theme/middleware.config.js
+++ b/packages/commercetools/theme/middleware.config.js
@@ -22,10 +22,11 @@ module.exports = {
           ]
         },
         serverApi: {
-          clientId: 'kuFT95wdTP4uH_hVOKjqfGEo',
-          clientSecret: 'tklIDic86mgWrFy0oBHRQQmwX7ZC5wIP',
+          clientId: 'XPVdGFHqZwAaR2rQQEu0cXU-',
+          clientSecret: 'bpDi7aApbmeQjSnCJT_KL-YymzEjxrUq',
           scopes: [
-            'manage_project:vsf-ct-dev'
+            'manage_customers:vsf-ct-dev',
+            'manage_products:vsf-ct-dev'
           ]
         },
         currency: 'USD',

--- a/packages/core/docs/commercetools/changelog/6403_1.js
+++ b/packages/core/docs/commercetools/changelog/6403_1.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fix `Insufficient scope` error when resetting customer\'s password',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6403',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};

--- a/packages/core/docs/commercetools/changelog/6403_2.js
+++ b/packages/core/docs/commercetools/changelog/6403_2.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Allow defining custom GraphQL operations that will be called with server API client',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6403',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};

--- a/packages/core/docs/commercetools/migrate/1.3.3/index.md
+++ b/packages/core/docs/commercetools/migrate/1.3.3/index.md
@@ -1,0 +1,74 @@
+# Upgrading to 1.3.3
+
+## Introduction
+
+In the 1.3.3 release, we added new options to the `serverApi` introduced in the 1.3.2 release.
+
+## Changes
+
+In the 1.3.2 release, we introduced a new key named `serverApi` to the commercetools middleware configuration. It stores API client used to generate access tokens for selected operations. However, we quickly noticed the need to allow adding other operations that will use these access tokens. That's why in this release we added new `operations` option to the `serverApi` configuration.
+
+```javascript{9-15}
+// middleware.config.js
+module.exports = {
+  integrations: {
+    ct: {
+      location: '@vue-storefront/commercetools-api/server',
+      configuration: {
+        // irrelevant configuration was omitted for readability
+        serverApi: {
+          clientId: 'SERVER_ID',
+          clientSecret: 'SERVER_SECRET',
+          scopes: [
+            'manage_customers:PROJECT_KEY',
+            'manage_products:PROJECT_KEY'
+          ],
+          operations: []
+        }
+      }
+    }
+  }
+};
+```
+
+:::warning Custom operations might require additional scopes
+Remember that custom operations added to the `operations` array might require additional scopes.
+:::
+
+
+### Example
+
+Let's assume you have custom GraphQL that adds new mutation like shown below:
+
+```graphql
+mutation AddProductType(
+  $draft: ProductTypeDraft!
+) {
+  productType: createProductType(draft: $draft) {
+    name
+    description
+    key
+  }
+}
+```
+
+In this case, you need to add `createProductType` to the `operations` array:
+
+```javascript{9-11}
+// middleware.config.js
+module.exports = {
+  integrations: {
+    ct: {
+      location: '@vue-storefront/commercetools-api/server',
+      configuration: {
+        // irrelevant configuration was omitted for readability
+        serverApi: {
+          operations: [
+            'createProductType'
+          ]
+        }
+      }
+    }
+  }
+};
+```

--- a/packages/core/docs/commercetools/migrate/index.md
+++ b/packages/core/docs/commercetools/migrate/index.md
@@ -1,5 +1,6 @@
 # Migration guides
 
+- [1.3.3](./1.3.3/index.md)
 - [1.3.0](./1.3.0/index.md)
 - [1.2.0](./1.2.0/index.md)
 - [1.2.0-rc.3](./1.2.0-rc.3/index.md)


### PR DESCRIPTION
This PR changes the following:
* changes API client in the `serverApi` to one with the only scopes that the server needs;
* adds scopes required to successfully reset customer's password;
* allows defining custom GraphQL operations that will be called with server API client

## Related Issue
https://github.com/vuestorefront/vue-storefront/issues/6401 - [Forgot Password] Insufficient scope on `customerResetPassword`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.

#### Changelog
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Code standards
- [X] My code follows the code style of this project.
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.

