### PR TITLE
feat(perf): runtime caching using composables' shared refs

### DIFF
--- a/packages/commercetools/api-client/__tests__/helpers/commercetoolsLink/linkHandlers.spec.ts
+++ b/packages/commercetools/api-client/__tests__/helpers/commercetoolsLink/linkHandlers.spec.ts
@@ -19,6 +19,7 @@ describe('[commercetools-helpers] handleBeforeAuth', () => {
   it('doesnt generate access token for guest on users related operations', async () => {
     const scope = '';
     const result = await handleBeforeAuth({
+      settings: {},
       sdkAuth: getSdkAuth(scope),
       tokenProvider: getTokenProvider(scope),
       apolloReq: { operationName: 'customerSignMeIn' },
@@ -31,6 +32,7 @@ describe('[commercetools-helpers] handleBeforeAuth', () => {
   it('generates access token for guest on anonymous-session allowed operations', async () => {
     const scope = '';
     const result = await handleBeforeAuth({
+      settings: {},
       sdkAuth: getSdkAuth(scope),
       tokenProvider: getTokenProvider(scope),
       apolloReq: { operationName: 'createCart' },
@@ -43,6 +45,7 @@ describe('[commercetools-helpers] handleBeforeAuth', () => {
   it('returns current token for anonymous user', async () => {
     const scope = 'anonymous_id';
     const result = await handleBeforeAuth({
+      settings: {},
       sdkAuth: getSdkAuth(scope),
       tokenProvider: getTokenProvider(scope),
       apolloReq: { operationName: 'customerSignMeIn' },
@@ -55,6 +58,7 @@ describe('[commercetools-helpers] handleBeforeAuth', () => {
   it('returns current token for logged in user', async () => {
     const scope = 'customer_id';
     const result = await handleBeforeAuth({
+      settings: {},
       sdkAuth: getSdkAuth(scope),
       tokenProvider: getTokenProvider(scope),
       apolloReq: { operationName: 'customerSignMeIn' },
@@ -140,7 +144,7 @@ describe('[commercetools-helpers] handleRetry', () => {
 
   it('defaults to false', () => {
     const tokenProvider = getTokenProvider('');
-    const handler = handleRetry({ tokenProvider });
+    const handler = handleRetry({ settings: {}, tokenProvider });
     const operation = { operationName: 'any' };
     const error = { result: { message: '' } };
 
@@ -150,7 +154,7 @@ describe('[commercetools-helpers] handleRetry', () => {
 
   it('doesnt run more than 3 times', () => {
     const tokenProvider = getTokenProvider('');
-    const handler = handleRetry({ tokenProvider });
+    const handler = handleRetry({ settings: {}, tokenProvider });
     const operation = { operationName: 'any' };
     const error = { result: { message: 'invalid_token' } };
 
@@ -160,7 +164,7 @@ describe('[commercetools-helpers] handleRetry', () => {
 
   it('calls "invalidateTokenInfo" on "invalid_token" error', () => {
     const tokenProvider = getTokenProvider('');
-    const handler = handleRetry({ tokenProvider });
+    const handler = handleRetry({ settings: {}, tokenProvider });
     const operation = { operationName: 'any' };
     const error = { result: { message: 'invalid_token' } };
 

--- a/packages/commercetools/composables/__tests__/useFacet/useFacet.spec.ts
+++ b/packages/commercetools/composables/__tests__/useFacet/useFacet.spec.ts
@@ -26,9 +26,9 @@ const context = {
           }
         }
       })),
-      getCategory: jest.fn(() => ({
+      categorySearch: jest.fn(() => ({
         data: {
-          categories: {
+          categorySearch: {
             results: [{ id: 1, name: 'cat1' }]
           }
         }
@@ -61,7 +61,7 @@ describe('[commercetools-composables] useFacet', () => {
       }
     } as any);
 
-    expect(context.$ct.api.getCategory).toBeCalled();
+    expect(context.$ct.api.categorySearch).toBeCalled();
     expect(context.$ct.api.getProduct).toBeCalled();
     expect(enhanceProduct).toBeCalled();
     expect(getFiltersFromProductsAttributes).toBeCalled();

--- a/packages/commercetools/composables/src/helpers/internals/enhanceProduct.ts
+++ b/packages/commercetools/composables/src/helpers/internals/enhanceProduct.ts
@@ -37,7 +37,8 @@ const enhanceProduct = (productResponse: ApolloQueryResult<ProductData>, context
         _master: current.masterVariant.id === variant.id,
         _description: current.description,
         _categoriesRef: current.categoriesRef.map((cr) => cr.id),
-        _rating: (product as any).reviewRatingStatistics
+        _rating: (product as any).reviewRatingStatistics,
+        ...(product.productType && { _productType: product.productType })
       }));
     })
     .reduce((prev, curr) => [...prev, ...curr], []);

--- a/packages/core/core/__tests__/factories/useCategoryFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/useCategoryFactory.spec.ts
@@ -1,5 +1,6 @@
 import { useCategoryFactory, UseCategoryFactoryParams } from '../../src/factories';
 import { UseCategory } from '../../src/types';
+import { isCacheValid } from '../../src/utils';
 
 let useCategory: (cacheId?: string) => UseCategory<any, any>;
 let params: UseCategoryFactoryParams<any, any>;
@@ -35,6 +36,9 @@ describe('[CORE - factories] useCategoryFactory', () => {
   });
 
   describe('methods', () => {
+    beforeEach(() => {
+      (isCacheValid as any).mockReturnValue(false);
+    });
     describe('search', () => {
       it('should invoke search', async () => {
         const { categories, search } = useCategory();
@@ -42,6 +46,22 @@ describe('[CORE - factories] useCategoryFactory', () => {
         await search({ someparam: 'qwerty' });
         expect(params.categorySearch).toBeCalledWith({ someparam: 'qwerty' });
         expect(categories.value).toEqual({ id: 'mocked_removed_cart' });
+      });
+
+      it('should not invoke content search when isCacheValid returns true', async () => {
+        (isCacheValid as any).mockReturnValue(true);
+        const { search } = useCategory();
+        const searchParams = { someparam: 'qwerty' };
+        await search(searchParams);
+        expect(params.categorySearch).toBeCalledTimes(0);
+      });
+
+      it('should invoke content search when isCacheValid returns true and force param is true', async () => {
+        (isCacheValid as any).mockReturnValue(true);
+        const { search } = useCategory();
+        const searchParams = { someparam: 'qwerty' };
+        await search(searchParams, true);
+        expect(params.categorySearch).toBeCalledTimes(1);
       });
 
       it('should set error if factory method throwed', async () => {

--- a/packages/core/core/__tests__/factories/useProductFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/useProductFactory.spec.ts
@@ -1,5 +1,6 @@
 import { useProductFactory } from '../../src/factories';
 import { UseProduct } from '../../src/types';
+import { isCacheValid } from '../../src/utils';
 
 const useProduct: (cacheId: string) => UseProduct<any, any> = useProductFactory<any, any>({
   productsSearch: (searchParams) => Promise.resolve([{ name: 'product ' + searchParams.slug }])
@@ -12,6 +13,10 @@ const factoryParams = {
 const useProductMock = useProductFactory<any, any>(factoryParams);
 
 describe('[CORE - factories] useProductFactory', () => {
+  beforeEach(() => {
+    (isCacheValid as any).mockReturnValue(false);
+  });
+
   it('creates properties', () => {
     const { products, loading } = useProduct('test-product');
 
@@ -32,6 +37,22 @@ describe('[CORE - factories] useProductFactory', () => {
 
     await search({ slug: 'product-slug' });
 
+    expect(products.value).toEqual([{name: 'product product-slug' }]);
+  });
+
+  it('does not invoke content search when isCacheValid returns true', async () => {
+    (isCacheValid as any).mockReturnValue(true);
+    const { search, products } = useProduct('test-use-product');
+    await search({ slug: 'product-slug' });
+    expect(products.value).toEqual([]);
+
+  });
+
+  it('invokes content search when isCacheValid returns true and force param is true', async () => {
+    (isCacheValid as any).mockReturnValue(true);
+    const { search, products } = useProduct('test-use-product');
+    const searchParams = { slug: 'product-slug' };
+    await search(searchParams, true);
     expect(products.value).toEqual([{name: 'product product-slug' }]);
   });
 

--- a/packages/core/core/__tests__/setup.ts
+++ b/packages/core/core/__tests__/setup.ts
@@ -22,7 +22,9 @@ jest.mock('../src/utils', () => ({
   vsfRef: jest.fn(ref),
   generateContext: jest.fn(() => ({ context: null })),
   configureFactoryParams: jest.fn((fParams) => fParams),
-  useVSFContext: jest.fn()
+  useVSFContext: jest.fn(),
+  setCacheTimestamp: jest.fn(() => ref(1)),
+  isCacheValid: jest.fn()
 }));
 
 // @ts-ignore

--- a/packages/core/core/__tests__/utils/runtimeCache.spec.ts
+++ b/packages/core/core/__tests__/utils/runtimeCache.spec.ts
@@ -82,6 +82,11 @@ describe('runtimeCacheHelpers', () => {
       beforeEach(() => {
         jest.restoreAllMocks();
       });
+      it('when content is truthy and cacheTimeToLive param hasn\'t been passed', () => {
+        const timestamp = ref(1);
+        const content = ref(['non-empty', 'content']);
+        expect(isCacheValid(content, timestamp)).toBe(true);
+      });
       it('when cacheLife is less than cacheTimeToLive', () => {
         const timestamp = ref(Date.now());
         const content = ref(['non-empty', 'content']);

--- a/packages/core/core/__tests__/utils/runtimeCache.spec.ts
+++ b/packages/core/core/__tests__/utils/runtimeCache.spec.ts
@@ -48,4 +48,17 @@ describe('runtimeCacheHelpers', () => {
       expect(timestamp).toBe(mockedDateValue);
     });
   });
+
+  describe('>isCacheValid', () => {
+    describe('returns false', () => {
+      it('when content is falsy', () => {});
+      it('when content is an empty array', () => {});
+      it('when content is an empty object', () => {});
+      it('when cacheLife is greater than cacheTimeToLive', () => {});
+    });
+
+    describe('returns true', () => {
+      it('when cacheLife is less than cacheTimeToLive', () => {});
+    });
+  });
 });

--- a/packages/core/core/__tests__/utils/runtimeCache.spec.ts
+++ b/packages/core/core/__tests__/utils/runtimeCache.spec.ts
@@ -1,0 +1,51 @@
+import { setCacheTimestamp } from '../../src/utils/runtimeCache';
+import { useVSFContext, sharedRef } from '../../src/utils';
+
+describe('runtimeCacheHelpers', () => {
+  describe('>setCacheTimestamp', () => {
+    let $sharedRefsMap;
+    let mockedDateValue;
+
+    const mockVSFContext = () => {
+      $sharedRefsMap = new Map();
+      (useVSFContext as any).mockImplementation(() => ({ $sharedRefsMap }));
+    };
+    const mockDateNow = () => {
+      mockedDateValue = 12345;
+      Date.now = jest.fn(() => mockedDateValue);
+    };
+    const mockSharedRef = () => {
+      (sharedRef as any).mockImplementation((value, key) => {
+        $sharedRefsMap.set(key, value);
+        return value;
+      });
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockVSFContext();
+      mockDateNow();
+      mockSharedRef();
+    });
+
+    it('sets the new timestamp equal to Date.now() on the $sharedRefsMap', () => {
+      const key = 'new-timestamp';
+      setCacheTimestamp(key);
+      expect($sharedRefsMap.get(key)).toBe(mockedDateValue);
+    });
+
+    it('returns the existing timestamp', () => {
+      const key = 'existing-timestamp';
+      const existingTimestamp = 123;
+      $sharedRefsMap.set(key, existingTimestamp);
+      const timestamp = setCacheTimestamp(key);
+      expect(timestamp).toBe(existingTimestamp);
+    });
+
+    it('returns the new timestamp', () => {
+      const key = 'new-timestamp';
+      const timestamp = setCacheTimestamp(key);
+      expect(timestamp).toBe(mockedDateValue);
+    });
+  });
+});

--- a/packages/core/core/src/factories/useCategoryFactory.ts
+++ b/packages/core/core/src/factories/useCategoryFactory.ts
@@ -28,7 +28,7 @@ export function useCategoryFactory<CATEGORY, CATEGORY_SEARCH_PARAMS, API extends
 
     const search = async (searchParams, force = false) => {
       Logger.debug(`useCategory/${id}/search`, searchParams);
-      if (isCacheValid(categories, `useCategory-cache-${id}`, cacheTimeToLive) && !force) return;
+      if (!force && isCacheValid(categories, cacheTimestamp, cacheTimeToLive)) return;
       try {
         loading.value = true;
         categories.value = await _factoryParams.categorySearch(searchParams);

--- a/packages/core/core/src/factories/useCategoryFactory.ts
+++ b/packages/core/core/src/factories/useCategoryFactory.ts
@@ -13,7 +13,7 @@ export interface UseCategoryFactoryParams<
 export function useCategoryFactory<CATEGORY, CATEGORY_SEARCH_PARAMS, API extends PlatformApi = any>(
   factoryParams: UseCategoryFactoryParams<CATEGORY, CATEGORY_SEARCH_PARAMS, API>
 ) {
-  return function useCategory(id: string, cacheTimeToLive: number): UseCategory<CATEGORY, CATEGORY_SEARCH_PARAMS, API> {
+  return function useCategory(id: string, cacheTimeToLive?: number): UseCategory<CATEGORY, CATEGORY_SEARCH_PARAMS, API> {
     const categories: Ref<CATEGORY[]> = sharedRef([], `useCategory-categories-${id}`);
     const loading = sharedRef(false, `useCategory-loading-${id}`);
     const error: Ref<UseCategoryErrors> = sharedRef({

--- a/packages/core/core/src/factories/useCategoryFactory.ts
+++ b/packages/core/core/src/factories/useCategoryFactory.ts
@@ -1,6 +1,6 @@
 import { CustomQuery, UseCategory, Context, FactoryParams, UseCategoryErrors, PlatformApi } from '../types';
 import { Ref, computed } from '@vue/composition-api';
-import { sharedRef, Logger, configureFactoryParams } from '../utils';
+import { sharedRef, Logger, configureFactoryParams, setCacheTimestamp, isCacheValid } from '../utils';
 
 export interface UseCategoryFactoryParams<
   CATEGORY,
@@ -13,25 +13,27 @@ export interface UseCategoryFactoryParams<
 export function useCategoryFactory<CATEGORY, CATEGORY_SEARCH_PARAMS, API extends PlatformApi = any>(
   factoryParams: UseCategoryFactoryParams<CATEGORY, CATEGORY_SEARCH_PARAMS, API>
 ) {
-  return function useCategory(id: string): UseCategory<CATEGORY, CATEGORY_SEARCH_PARAMS, API> {
+  return function useCategory(id: string, cacheTimeToLive: number): UseCategory<CATEGORY, CATEGORY_SEARCH_PARAMS, API> {
     const categories: Ref<CATEGORY[]> = sharedRef([], `useCategory-categories-${id}`);
     const loading = sharedRef(false, `useCategory-loading-${id}`);
     const error: Ref<UseCategoryErrors> = sharedRef({
       search: null
     }, `useCategory-error-${id}`);
+    const cacheTimestamp: Ref<number> = setCacheTimestamp(`useCategory-cache-${id}`);
 
     const _factoryParams = configureFactoryParams(
       factoryParams,
       { mainRef: categories, alias: 'currentCategories', loading, error }
     );
 
-    const search = async (searchParams) => {
+    const search = async (searchParams, force = false) => {
       Logger.debug(`useCategory/${id}/search`, searchParams);
-
+      if (isCacheValid(categories, `useCategory-cache-${id}`, cacheTimeToLive) && !force) return;
       try {
         loading.value = true;
         categories.value = await _factoryParams.categorySearch(searchParams);
         error.value.search = null;
+        cacheTimestamp.value = Date.now();
       } catch (err) {
         error.value.search = err;
         Logger.error(`useCategory/${id}/search`, err);
@@ -45,7 +47,8 @@ export function useCategoryFactory<CATEGORY, CATEGORY_SEARCH_PARAMS, API extends
       search,
       loading: computed(() => loading.value),
       categories: computed(() => categories.value),
-      error: computed(() => error.value)
+      error: computed(() => error.value),
+      cacheTimestamp: computed(() => cacheTimestamp.value)
     };
   };
 }

--- a/packages/core/core/src/factories/useContentFactory.ts
+++ b/packages/core/core/src/factories/useContentFactory.ts
@@ -29,7 +29,7 @@ export function useContentFactory<CONTENT, CONTENT_SEARCH_PARAMS, API extends Pl
 
     const search = async(params: CONTENT_SEARCH_PARAMS, force = false): Promise<void> => {
       Logger.debug(`useContent/${id}/search`, params);
-      if (isCacheValid(content, `useContent-cache-${id}`, cacheTimeToLive) && !force) return;
+      if (!force && isCacheValid(content, cacheTimestamp, cacheTimeToLive)) return;
       try {
         loading.value = true;
         content.value = await _factoryParams.search(params);

--- a/packages/core/core/src/factories/useContentFactory.ts
+++ b/packages/core/core/src/factories/useContentFactory.ts
@@ -14,7 +14,7 @@ export interface UseContentFactoryParams<
 export function useContentFactory<CONTENT, CONTENT_SEARCH_PARAMS, API extends PlatformApi = any>(
   factoryParams: UseContentFactoryParams<CONTENT, CONTENT_SEARCH_PARAMS, API>
 ) {
-  return function useContent(id: string, cacheTimeToLive: number): UseContent<CONTENT, CONTENT_SEARCH_PARAMS, API> {
+  return function useContent(id: string, cacheTimeToLive?: number): UseContent<CONTENT, CONTENT_SEARCH_PARAMS, API> {
     const content: Ref<CONTENT> = sharedRef([], `useContent-content-${id}`);
     const loading: Ref<boolean> = sharedRef(false, `useContent-loading-${id}`);
     const error: Ref<UseContentErrors> = sharedRef({

--- a/packages/core/core/src/factories/useProductFactory.ts
+++ b/packages/core/core/src/factories/useProductFactory.ts
@@ -20,7 +20,7 @@ API extends PlatformApi = any
 export function useProductFactory<PRODUCTS, PRODUCT_SEARCH_PARAMS, API extends PlatformApi = any>(
   factoryParams: UseProductFactoryParams<PRODUCTS, PRODUCT_SEARCH_PARAMS, API>
 ) {
-  return function useProduct(id: string, cacheTimeToLive: number): UseProduct<PRODUCTS, PRODUCT_SEARCH_PARAMS, API> {
+  return function useProduct(id: string, cacheTimeToLive?: number): UseProduct<PRODUCTS, PRODUCT_SEARCH_PARAMS, API> {
     const products: Ref<PRODUCTS> = sharedRef([], `useProduct-products-${id}`);
     const loading = sharedRef(false, `useProduct-loading-${id}`);
     const error: Ref<UseProductErrors> = sharedRef({

--- a/packages/core/core/src/factories/useProductFactory.ts
+++ b/packages/core/core/src/factories/useProductFactory.ts
@@ -35,7 +35,7 @@ export function useProductFactory<PRODUCTS, PRODUCT_SEARCH_PARAMS, API extends P
 
     const search = async (searchParams, force = false) => {
       Logger.debug(`useProduct/${id}/search`, searchParams);
-      if (isCacheValid(products, `useProduct-cache-${id}`, cacheTimeToLive) && !force) return;
+      if (!force && isCacheValid(products, cacheTimestamp, cacheTimeToLive)) return;
       try {
         loading.value = true;
         products.value = await _factoryParams.productsSearch(searchParams);

--- a/packages/core/core/src/factories/useReviewFactory.ts
+++ b/packages/core/core/src/factories/useReviewFactory.ts
@@ -15,7 +15,7 @@ export interface UseReviewFactoryParams<
 export function useReviewFactory<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAMS, API extends PlatformApi = any>(
   factoryParams: UseReviewFactoryParams<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAMS, API>
 ) {
-  return function useReview(id: string, cacheTimeToLive: number): UseReview<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAMS> {
+  return function useReview(id: string, cacheTimeToLive?: number): UseReview<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAMS> {
     const reviews: Ref<REVIEW> = sharedRef([], `useReviews-reviews-${id}`);
     const loading: Ref<boolean> = sharedRef(false, `useReviews-loading-${id}`);
     const error: Ref<UseReviewErrors> = sharedRef({

--- a/packages/core/core/src/factories/useReviewFactory.ts
+++ b/packages/core/core/src/factories/useReviewFactory.ts
@@ -31,7 +31,7 @@ export function useReviewFactory<REVIEW, REVIEWS_SEARCH_PARAMS, REVIEW_ADD_PARAM
 
     const search = async (searchParams, force = false): Promise<void> => {
       Logger.debug(`useReview/${id}/search`, searchParams);
-      if (isCacheValid(reviews, `useReviews-cache-${id}`, cacheTimeToLive) && !force) return;
+      if (!force && isCacheValid(reviews, cacheTimestamp, cacheTimeToLive)) return;
       try {
         loading.value = true;
         reviews.value = await _factoryParams.searchReviews(searchParams);

--- a/packages/core/core/src/factories/useSearchFactory.ts
+++ b/packages/core/core/src/factories/useSearchFactory.ts
@@ -9,7 +9,7 @@ export interface UseSearchFactoryParams<RESULT, SEARCH_PARAMS> extends FactoryPa
 export function useSearchFactory<RESULT, SEARCH_PARAMS>(
   factoryParams: UseSearchFactoryParams<RESULT, SEARCH_PARAMS>
 ) {
-  return function useSearch(id: string, cacheTimeToLive: number): UseSearch<RESULT, SEARCH_PARAMS> {
+  return function useSearch(id: string, cacheTimeToLive?: number): UseSearch<RESULT, SEARCH_PARAMS> {
     const result: Ref<RESULT> = sharedRef([], `useSearch-products-${id}`);
     const loading = sharedRef(false, `useSearch-loading-${id}`);
     const _factoryParams = configureFactoryParams(factoryParams);

--- a/packages/core/core/src/factories/useSearchFactory.ts
+++ b/packages/core/core/src/factories/useSearchFactory.ts
@@ -20,7 +20,7 @@ export function useSearchFactory<RESULT, SEARCH_PARAMS>(
 
     const search = async (searchParams, force = false) => {
       Logger.debug(`useSearch/${id}/search`, searchParams);
-      if (isCacheValid(result, `useSearch-cache-${id}`, cacheTimeToLive) && !force) return;
+      if (!force && isCacheValid(result, cacheTimestamp, cacheTimeToLive)) return;
       try {
         loading.value = true;
         result.value = await _factoryParams.search(searchParams);

--- a/packages/core/core/src/factories/useSearchFactory.ts
+++ b/packages/core/core/src/factories/useSearchFactory.ts
@@ -1,6 +1,6 @@
 import { CustomQuery, UseSearch, Context, FactoryParams, UseSearchErrors } from '../types';
 import { Ref, computed } from '@vue/composition-api';
-import { sharedRef, Logger, configureFactoryParams } from '../utils';
+import { sharedRef, Logger, configureFactoryParams, setCacheTimestamp, isCacheValid } from '../utils';
 
 export interface UseSearchFactoryParams<RESULT, SEARCH_PARAMS> extends FactoryParams {
   search: (context: Context, params: SEARCH_PARAMS & { customQuery?: CustomQuery }) => Promise<RESULT>;
@@ -9,21 +9,23 @@ export interface UseSearchFactoryParams<RESULT, SEARCH_PARAMS> extends FactoryPa
 export function useSearchFactory<RESULT, SEARCH_PARAMS>(
   factoryParams: UseSearchFactoryParams<RESULT, SEARCH_PARAMS>
 ) {
-  return function useSearch(id: string): UseSearch<RESULT, SEARCH_PARAMS> {
+  return function useSearch(id: string, cacheTimeToLive: number): UseSearch<RESULT, SEARCH_PARAMS> {
     const result: Ref<RESULT> = sharedRef([], `useSearch-products-${id}`);
     const loading = sharedRef(false, `useSearch-loading-${id}`);
     const _factoryParams = configureFactoryParams(factoryParams);
     const error: Ref<UseSearchErrors> = sharedRef({
       search: null
     }, `useSearch-error-${id}`);
+    const cacheTimestamp: Ref<number> = setCacheTimestamp(`useSearch-cache-${id}`);
 
-    const search = async (searchParams) => {
+    const search = async (searchParams, force = false) => {
       Logger.debug(`useSearch/${id}/search`, searchParams);
-
+      if (isCacheValid(result, `useSearch-cache-${id}`, cacheTimeToLive) && !force) return;
       try {
         loading.value = true;
         result.value = await _factoryParams.search(searchParams);
         error.value.search = null;
+        cacheTimestamp.value = Date.now();
       } catch (err) {
         error.value.search = err;
         Logger.error(`useSearch/${id}/search`, err);
@@ -36,7 +38,8 @@ export function useSearchFactory<RESULT, SEARCH_PARAMS>(
       search,
       result: computed(() => result.value),
       loading: computed(() => loading.value),
-      error: computed(() => error.value)
+      error: computed(() => error.value),
+      cacheTimestamp: computed(() => cacheTimestamp.value)
     };
   };
 }

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -473,7 +473,7 @@ export interface UseContent<
   CONTENT_SEARCH_PARAMS,
   API extends PlatformApi = any
 > extends Composable<API> {
-  search: (params: CONTENT_SEARCH_PARAMS) => Promise<void>;
+  search: (params: CONTENT_SEARCH_PARAMS, force?: boolean) => Promise<void>;
   content: ComputedProperty<CONTENT>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseContentErrors>;

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -100,6 +100,7 @@ export interface UseSearch<RESULT, SEARCH_PARAMS> {
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseSearchErrors>;
   search(params: ComposableFunctionArgs<SEARCH_PARAMS>): Promise<void>;
+  cacheTimestamp: ComputedProperty<number>;
 }
 
 export interface UseUserRegisterParams {

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -270,6 +270,7 @@ export interface UseCategory<
   search(params: ComposableFunctionArgs<CATEGORY_SEARCH_PARAMS>): Promise<void>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseCategoryErrors>;
+  cacheTimestamp: ComputedProperty<number>;
 }
 
 export interface UseCartErrors {

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -268,7 +268,7 @@ export interface UseCategory<
   API extends PlatformApi = any
 > extends Composable<API> {
   categories: ComputedProperty<CATEGORY[]>;
-  search(params: ComposableFunctionArgs<CATEGORY_SEARCH_PARAMS>): Promise<void>;
+  search(params: ComposableFunctionArgs<CATEGORY_SEARCH_PARAMS>, force?: boolean): Promise<void>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseCategoryErrors>;
   cacheTimestamp: ComputedProperty<number>;

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -475,6 +475,7 @@ export interface UseContent<
   content: ComputedProperty<CONTENT>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseContentErrors>;
+  cacheTimestamp: ComputedProperty<number>;
 }
 
 export interface RenderComponent {

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -78,7 +78,7 @@ export interface UseProduct<
   products: ComputedProperty<PRODUCTS>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseProductErrors>;
-  search(params: ComposableFunctionArgs<PRODUCT_SEARCH_PARAMS>): Promise<void>;
+  search(params: ComposableFunctionArgs<PRODUCT_SEARCH_PARAMS>, force?: boolean): Promise<void>;
   [x: string]: any;
 }
 

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -380,7 +380,7 @@ REVIEWS_SEARCH_PARAMS,
 REVIEW_ADD_PARAMS,
 API extends PlatformApi = any
 > extends Composable<API> {
-  search(params: ComposableFunctionArgs<REVIEWS_SEARCH_PARAMS>): Promise<void>;
+  search(params: ComposableFunctionArgs<REVIEWS_SEARCH_PARAMS>, force?: boolean): Promise<void>;
   addReview(params: ComposableFunctionArgs<REVIEW_ADD_PARAMS>): Promise<void>;
   error: ComputedProperty<UseReviewErrors>;
   reviews: ComputedProperty<REVIEW>;

--- a/packages/core/core/src/utils/index.ts
+++ b/packages/core/core/src/utils/index.ts
@@ -8,6 +8,7 @@ import mask from './logger/mask';
 import { useVSFContext, configureContext, generateContext } from './context';
 import { integrationPlugin } from './nuxt';
 import { configureFactoryParams } from './factoryParams';
+import { setCacheTimestamp, isCacheValid } from './runtimeCache';
 
 export {
   wrap,
@@ -22,5 +23,7 @@ export {
   useVSFContext,
   configureFactoryParams,
   generateContext,
-  integrationPlugin
+  integrationPlugin,
+  setCacheTimestamp,
+  isCacheValid
 };

--- a/packages/core/core/src/utils/runtimeCache/index.ts
+++ b/packages/core/core/src/utils/runtimeCache/index.ts
@@ -1,0 +1,28 @@
+import { useVSFContext, sharedRef } from '../';
+
+export const setCacheTimestamp = (key: string) => {
+  const { $sharedRefsMap } = useVSFContext();
+  const existingTimestamp = $sharedRefsMap.get(key);
+  if (existingTimestamp) return existingTimestamp;
+  const timestamp = sharedRef(Date.now(), key);
+  return timestamp;
+};
+
+export const isCacheValid = (
+  content: any,
+  key: string,
+  cacheTimeToLive = 300
+) => {
+  const { $sharedRefsMap } = useVSFContext();
+  const isContentCached = content.value.length;
+  if (isContentCached) {
+    const timestamp = $sharedRefsMap.get(key);
+    const now = Date.now();
+    const cacheLife = (now - timestamp.value) / 1000;
+    if (cacheLife < cacheTimeToLive) {
+      return true;
+    }
+  } else {
+    return false;
+  }
+};

--- a/packages/core/core/src/utils/runtimeCache/index.ts
+++ b/packages/core/core/src/utils/runtimeCache/index.ts
@@ -24,9 +24,7 @@ export const isCacheValid = (
   if (_isContentCached(content.value)) {
     const now = Date.now();
     const cacheLife = (now - timestamp.value) / 1000;
-    if (cacheLife < cacheTimeToLive) {
-      return true;
-    }
+    return cacheLife < cacheTimeToLive;
   } else {
     return false;
   }

--- a/packages/core/core/src/utils/runtimeCache/index.ts
+++ b/packages/core/core/src/utils/runtimeCache/index.ts
@@ -4,7 +4,7 @@ import { Ref } from '@vue/composition-api';
 const _isContentCached = (content) => {
   if (!content) return false;
   if (Array.isArray(content)) return content.length;
-  if (typeof content === 'object') return Object.keys(content.value).length;
+  if (typeof content === 'object') return Object.keys(content).length;
   return true;
 };
 

--- a/packages/core/core/src/utils/runtimeCache/index.ts
+++ b/packages/core/core/src/utils/runtimeCache/index.ts
@@ -21,8 +21,7 @@ export const isCacheValid = (
   timestamp: Ref<number>,
   cacheTimeToLive = 300
 ) => {
-  const isContentCached = _isContentCached(content.value);
-  if (isContentCached) {
+  if (_isContentCached(content.value)) {
     const now = Date.now();
     const cacheLife = (now - timestamp.value) / 1000;
     if (cacheLife < cacheTimeToLive) {

--- a/packages/core/core/src/utils/runtimeCache/index.ts
+++ b/packages/core/core/src/utils/runtimeCache/index.ts
@@ -19,9 +19,10 @@ export const setCacheTimestamp = (key: string) => {
 export const isCacheValid = (
   content: any,
   timestamp: Ref<number>,
-  cacheTimeToLive = 300
+  cacheTimeToLive?: number
 ) => {
   if (_isContentCached(content.value)) {
+    if (!cacheTimeToLive) return true;
     const now = Date.now();
     const cacheLife = (now - timestamp.value) / 1000;
     return cacheLife < cacheTimeToLive;

--- a/packages/core/core/src/utils/runtimeCache/index.ts
+++ b/packages/core/core/src/utils/runtimeCache/index.ts
@@ -1,6 +1,13 @@
 import { useVSFContext, sharedRef } from '../';
 import { Ref } from '@vue/composition-api';
 
+const _isContentCached = (content) => {
+  if (!content) return false;
+  if (Array.isArray(content)) return content.length;
+  if (typeof content === 'object') return Object.keys(content.value).length;
+  return true;
+};
+
 export const setCacheTimestamp = (key: string) => {
   const { $sharedRefsMap } = useVSFContext();
   const existingTimestamp = $sharedRefsMap.get(key);
@@ -14,7 +21,7 @@ export const isCacheValid = (
   timestamp: Ref<number>,
   cacheTimeToLive = 300
 ) => {
-  const isContentCached = content.value.length;
+  const isContentCached = _isContentCached(content.value);
   if (isContentCached) {
     const now = Date.now();
     const cacheLife = (now - timestamp.value) / 1000;

--- a/packages/core/core/src/utils/runtimeCache/index.ts
+++ b/packages/core/core/src/utils/runtimeCache/index.ts
@@ -1,4 +1,5 @@
 import { useVSFContext, sharedRef } from '../';
+import { Ref } from '@vue/composition-api';
 
 export const setCacheTimestamp = (key: string) => {
   const { $sharedRefsMap } = useVSFContext();
@@ -10,13 +11,11 @@ export const setCacheTimestamp = (key: string) => {
 
 export const isCacheValid = (
   content: any,
-  key: string,
+  timestamp: Ref<number>,
   cacheTimeToLive = 300
 ) => {
-  const { $sharedRefsMap } = useVSFContext();
   const isContentCached = content.value.length;
   if (isContentCached) {
-    const timestamp = $sharedRefsMap.get(key);
     const now = Date.now();
     const cacheLife = (now - timestamp.value) / 1000;
     if (cacheLife < cacheTimeToLive) {

--- a/packages/core/docs/commercetools/changelog/6347.js
+++ b/packages/core/docs/commercetools/changelog/6347.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'getProduct custom query - productType doesnt get mapped to product response in enhanceProduct helper',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/6347',
+  isBreaking: false,
+  author: 'Marcin Sulowski',
+  linkToGitHubAccount: 'https://github.com/MarcinSulowski'
+};

--- a/packages/core/docs/core/changelog/6356.js
+++ b/packages/core/docs/core/changelog/6356.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fixed adding items to cart from list view in category page',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6356',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Dawid Ziobro',
+  linkToGitHubAccount: 'https://github.com/dawid-ziobro'
+};

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -211,7 +211,7 @@ import {
   SfColor,
   SfProperty
 } from '@storefront-ui/vue';
-import { computed } from '@vue/composition-api';
+import { computed, ref } from '@vue/composition-api';
 import { useCart, useWishlist, productGetters, useFacet, facetGetters } from '<%= options.generate.replace.composables %>';
 import { useUiHelpers, useUiState } from '~/composables';
 import { onSSR } from '@vue-storefront/core';
@@ -233,6 +233,7 @@ export default {
     const { addItem: addItemToWishlist, isInWishlist, removeItem: removeItemFromWishlist } = useWishlist();
     const { result, search, loading, error } = useFacet();
 
+    const productsQuantity = ref({});
     const products = computed(() => facetGetters.getProducts(result.value));
     const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
     const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value));
@@ -268,7 +269,8 @@ export default {
       removeItemFromWishlist,
       isInWishlist,
       addItemToCart,
-      isInCart
+      isInCart,
+      productsQuantity
     };
   },
   components: {


### PR DESCRIPTION
## Motivation
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
In our core, there are **5** composable factories which use the `sharedRef` util:
- useContentFactory
- useProductFactory
- useCategoryFactory
- useReviewFactory
- useSearchFactory

The content we fetch using their `search` method persists in `$sharedRefsMap`. However, with the current implementation, we rarely make use of it. You can observe that in projects where we have dynamic pages built from data coming from some CMS:

https://www.loom.com/share/9e5b84c1417645b28fac5ef3abfbdb51

In the example above we had requests for content and products (a couple of them). Every time we go back to the first page, the app re-fetches the data we already have in our "store". By utilizing the new runtime cache mechanisms, we can save bandwidth and speed up the process of navigating back to certain pages (or navigating to pages for the same time if they rely on data we've already cached!):

https://www.loom.com/share/276a72cfca39415b9b98483bd94563eb

## Description
Runtime caching is now possible thanks to the new logic inside the aforementioned composables' search methods. Whether the data will be re-fetched or not, depends on a couple of factors:
```
if (!force && isCacheValid(products, cacheTimestamp, cacheTimeToLive)) return;
```
`isCacheValid` is a utility function that will return `true` when the data we want to fetch already exists in the store or the time that has elapsed since the timestamp had been created does not exceed the `cacheTimeToLive` value. It takes in three parameters.
```ts
export const isCacheValid = (
  content: any,
  timestamp: Ref<number>,
  cacheTimeToLive?: number
) => {
```
`cacheTimeToLive` value can be passed to the composable as the second argument:
```
const { search, products } = useProduct('universal-id', 300);
```
`cacheTimestamp` is a `sharedRef` created by the second utility function this PR adds: `setCacheTimestamp`.
```
const cacheTimestamp: Ref<number> = setCacheTimestamp(`useProduct-cache-${id}`);
```
If re-fetching the data regardless of the `isCacheValid` return value is what we need, we can always use the `force` param that gives us full control over that. It is disabled by default:
```
const search = async (searchParams, force = false)
```

Long story short, by passing `cacheTimeToLive` and `force` params in certain ways, we can achieve three runtime caching strategies in VSF:
- If you want the fetched content to be cached forever and never be re-fetched (that is, as long as you stay in the SPA mode), do not pass the `cacheTimeToLive` argument to the composable.
- If you want the fetched content to be cached only for a given time, pass the `cacheTimeToLive` argument to the composable. Important! The unit of `cacheTimeToLive` is **seconds**. I.e. if you pass value `300`, your content will be cached for 300 seconds which equals 5 minutes. If this time elapses, your composable will re-fetch the data.
- If you don't want the fetched content to be cached at all, set the the `force` parameter of the composable's search method to `true` (or any other "truthy" value). It should be passed as the last argument.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [x] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

