### PR TITLE
fix: shipping method radio button

### DIFF
--- a/packages/commercetools/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/commercetools/theme/components/Checkout/VsfShippingProvider.vue
@@ -25,7 +25,7 @@
             :label="method.name"
             :value="method.id"
             :selected="selectedShippingMethod && selectedShippingMethod.shippingMethod && selectedShippingMethod.shippingMethod.id"
-            @change="selectShippingMethod(method)"
+            @input="selectShippingMethod(method)"
             name="shippingMethod"
             :description="method.localizedDescription"
             class="form__radio shipping"


### PR DESCRIPTION
event changed from `change` to `input`

## Description
with `change` event shipping method didn't work properly - discovered in enterprise theme

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!-- VSF 1 only -->
> I tested manually my code, and it works well with both:
- [x] Default Theme
- [ ] Capybara Theme

#### Code standards
- [ ] My code follows the code style of this project.
<!-- VSF 2 only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

