### PR TITLE
fix(os-203): fixed adding custom router.base property breaks api calls

### DIFF
--- a/packages/boilerplate/theme/nuxt.config.js
+++ b/packages/boilerplate/theme/nuxt.config.js
@@ -19,7 +19,7 @@ export default {
       {
         rel: 'icon',
         type: 'image/x-icon',
-        href: '/favicon.ico'
+        href: './favicon.ico'
       },
       {
         rel: 'preconnect',

--- a/packages/core/core/src/utils/helpers/index.ts
+++ b/packages/core/core/src/utils/helpers/index.ts
@@ -1,0 +1,21 @@
+import { useRouter } from '@nuxtjs/composition-api';
+
+/**
+ * Adds prefix with base path configured in router.base to provided url
+ * @param {string} path - url to which base path will be added
+ * @returns Relative path prefixed with router.base or not modified absolute path (it needs start from http or https)
+ */
+function addBasePath (path: string): string {
+  const pattern = /^((http|https):\/\/)/;
+
+  if (pattern.test(path)) {
+    return path;
+  }
+
+  const basePath = (useRouter().options.base).slice(0, -1);
+  return `${basePath}${path}`;
+}
+
+export {
+  addBasePath
+};

--- a/packages/core/core/src/utils/index.ts
+++ b/packages/core/core/src/utils/index.ts
@@ -4,6 +4,7 @@ import { onSSR, vsfRef, configureSSR } from './ssr';
 import { sharedRef } from './shared';
 import wrap from './wrap';
 import { Logger, registerLogger } from './logger';
+import { addBasePath } from './helpers';
 import mask from './logger/mask';
 import { useVSFContext, configureContext, generateContext } from './context';
 import { integrationPlugin } from './nuxt';
@@ -24,5 +25,6 @@ export {
   configureFactoryParams,
   generateContext,
   integrationPlugin,
-  i18nRedirectsUtil
+  i18nRedirectsUtil,
+  addBasePath
 };

--- a/packages/core/core/src/utils/nuxt/_proxyUtils.ts
+++ b/packages/core/core/src/utils/nuxt/_proxyUtils.ts
@@ -9,14 +9,14 @@ interface CreateProxiedApiParams {
   tag: string;
 }
 
-export const getBaseUrl = (req: IncomingMessage) => {
-  if (!req) return '/api/';
+export const getBaseUrl = (req: IncomingMessage, basePath: string | undefined = '/'): string => {
+  if (!req) return `${basePath}api/`;
   const { headers } = req;
   const isHttps = require('is-https')(req);
   const scheme = isHttps ? 'https' : 'http';
   const host = headers['x-forwarded-host'] || headers.host;
 
-  return `${scheme}://${host}/api/`;
+  return `${scheme}://${host}${basePath}api/`;
 };
 
 export const createProxiedApi = ({ givenApi, client, tag }: CreateProxiedApiParams) => new Proxy(givenApi, {
@@ -39,7 +39,7 @@ export const getIntegrationConfig = (context: NuxtContext, configuration: any) =
   const cookie = getCookies(context);
   const initialConfig = merge({
     axios: {
-      baseURL: getBaseUrl(context?.req),
+      baseURL: getBaseUrl(context?.req, context?.base),
       headers: {
         ...(cookie ? { cookie } : {})
       }

--- a/packages/core/docs/changelog/6526.js
+++ b/packages/core/docs/changelog/6526.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fixed adding custom router.base property breaks api calls',
+  link: 'https://github.com/vuestorefront/vue-storefront/issues/6505',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Piotr Grzywa',
+  linkToGitHubAccount: 'https://github.com/PiotrGrzywa'
+};

--- a/packages/core/docs/guide/theme.md
+++ b/packages/core/docs/guide/theme.md
@@ -89,6 +89,45 @@ Out of the box, some routes are injected via `@vue-storefront/nuxt-theme` module
 
 To override existing routes or adding your own, use [extendRoutes](https://nuxtjs.org/guides/configuration-glossary/configuration-router#extendroutes) in `nuxt.config.js`. Additionally, Nuxt.js automatically registers components created in the `pages` folder as new routes. You can read more about this on the [File System Routing](https://nuxtjs.org/docs/2.x/features/file-system-routing/) page.
 
+### Router base property
+
+There is an option to set base URL for your store.
+
+This can be useful if you need to serve your store as a different context root, from within a bigger Web site.
+
+Add following configuration to `nuxt.config.js`
+```javascript
+// nuxt.config.js
+
+export default {
+  router: {
+    base: "/myShop/"
+  }
+};
+```
+
+:::warning Be careful
+When using base router property you need to wrap all assets relative links in addBasePath(), this will automatically add base path to them and prevent redirects. (example below)
+:::
+
+
+
+```javascript
+//use addBasePath on relative url
+<SfImage :src="addBasePath(`/homepage/imageA.webp`)" />
+<SfBanner :image="addBasePath('/homepage/bannerA.png')" />
+
+//In theme file import addBasePath from vue-storefront core
+import { addBasePath } from '@vue-storefront/core';
+
+setup() {
+  return {
+    // if you want to use it in template you need to exprt it
+    addBasePath
+  }
+}
+```
+
 ## Updating styles
 
 There are few ways of updating the default styles. Below we describe the most optimal ways for the most common cases.

--- a/packages/core/nuxt-theme-module/theme/components/AppFooter.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppFooter.vue
@@ -50,7 +50,7 @@
     </SfFooterColumn>
     <SfFooterColumn title="Social">
       <div class="footer__socials">
-        <SfImage class="footer__social-image" v-for="item in social" :key="item" :src="'/icons/'+item+'.svg'" :alt="item" width="32" height="32" />
+        <SfImage class="footer__social-image" v-for="item in social" :key="item" :src="addBasePath('/icons/'+item+'.svg')" :alt="item" width="32" height="32" />
       </div>
     </SfFooterColumn>
   </SfFooter>
@@ -58,6 +58,7 @@
 
 <script>
 import { SfFooter, SfList, SfImage, SfMenuItem } from '@storefront-ui/vue';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   components: {
@@ -65,6 +66,11 @@ export default {
     SfList,
     SfImage,
     SfMenuItem
+  },
+  setup() {
+    return {
+      addBasePath
+    };
   },
   data() {
     return {

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -8,7 +8,7 @@
       <!-- TODO: add mobile view buttons after SFUI team PR -->
       <template #logo>
         <nuxt-link :to="localePath({ name: 'home' })" class="sf-header__logo">
-          <SfImage src="/icons/logo.svg" alt="Vue Storefront Next" class="sf-header__logo-image"/>
+          <SfImage :src="addBasePath('/icons/logo.svg')" alt="Vue Storefront Next" class="sf-header__logo-image"/>
         </nuxt-link>
       </template>
       <template #navigation>
@@ -119,6 +119,7 @@ import {
 } from '@storefront-ui/vue/src/utilities/mobile-observer.js';
 import debounce from 'lodash.debounce';
 import mockedSearchProducts from '../mockedSearchProducts.json';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   components: {
@@ -222,7 +223,8 @@ export default {
       searchBarRef,
       isMobile,
       isMobileMenuOpen,
-      removeSearchResults
+      removeSearchResults,
+      addBasePath
     };
   }
 };

--- a/packages/core/nuxt-theme-module/theme/components/CartSidebar.vue
+++ b/packages/core/nuxt-theme-module/theme/components/CartSidebar.vue
@@ -23,7 +23,7 @@
                 v-for="product in products"
                 v-e2e="'collected-product'"
                 :key="cartGetters.getItemSku(product)"
-                :image="cartGetters.getItemImage(product)"
+                :image="addBasePath(cartGetters.getItemImage(product))"
                 :title="cartGetters.getItemName(product)"
                 :regular-price="$n(cartGetters.getItemPrice(product).regular, 'currency')"
                 :special-price="cartGetters.getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')"
@@ -62,7 +62,7 @@
             <SfImage
               alt="Empty bag"
               class="empty-cart__image"
-              src="/icons/empty-cart.svg"
+              :src="addBasePath('/icons/empty-cart.svg')"
             />
             <SfHeading
               title="Your cart is empty"
@@ -125,6 +125,7 @@ import { computed } from '@nuxtjs/composition-api';
 import { useCart, cartGetters } from '<%= options.generate.replace.composables %>';
 import { useUiState } from '~/composables';
 import debounce from 'lodash.debounce';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'Cart',
@@ -151,6 +152,7 @@ export default {
     }, 500);
 
     return {
+      addBasePath,
       updateQuantity,
       loading,
       products,

--- a/packages/core/nuxt-theme-module/theme/components/InstagramFeed.vue
+++ b/packages/core/nuxt-theme-module/theme/components/InstagramFeed.vue
@@ -3,28 +3,29 @@
     <div class="grid grid-images">
       <div class="grid__row">
         <div class="grid__col">
-          <SfImage v-if="isMobile" src="/homepage/imageAm.webp" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
-          <SfImage v-else src="/homepage/imageAd.webp" alt="katherina_trn" :width="470" :height="470">katherina_trn</SfImage>
+          <SfImage v-if="isMobile" :src="addBasePath('/homepage/imageAm.webp')" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
+          <SfImage v-else :src="addBasePath('/homepage/imageAd.webp')" alt="katherina_trn" :width="470" :height="470">katherina_trn</SfImage>
         </div>
         <div class="grid__col small">
-          <SfImage v-if="isMobile" src="/homepage/imageBm.webp" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
-          <SfImage v-else src="/homepage/imageCd.webp" alt="katherina_trn" :width="470" :height="160">katherina_trn</SfImage>
+          <SfImage v-if="isMobile" :src="addBasePath('/homepage/imageBm.webp')" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
+          <SfImage v-else :src="addBasePath('/homepage/imageCd.webp')" alt="katherina_trn" :width="470" :height="160">katherina_trn</SfImage>
         </div>
       </div>
       <div class="grid__row">
         <div class="grid__col small">
-          <SfImage v-if="isMobile" src="/homepage/imageCm.webp" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
-           <SfImage v-else src="/homepage/imageBd.webp" alt="katherina_trn" :width="470" :height="160">katherina_trn</SfImage>
+          <SfImage v-if="isMobile" :src="addBasePath('/homepage/imageCm.webp')" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
+           <SfImage v-else :src="addBasePath('/homepage/imageBd.webp')" alt="katherina_trn" :width="470" :height="160">katherina_trn</SfImage>
         </div>
         <div class="grid__col">
-          <SfImage v-if="isMobile" src="/homepage/imageDm.webp" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
-          <SfImage v-else src="/homepage/imageDd.webp" alt="katherina_trn" :width="470" :height="470">katherina_trn</SfImage>
+          <SfImage v-if="isMobile" :src="addBasePath('/homepage/imageDm.webp')" alt="katherina_trn" :width="160" :height="160">katherina_trn</SfImage>
+          <SfImage v-else :src="addBasePath('/homepage/imageDd.webp')" alt="katherina_trn" :width="470" :height="470">katherina_trn</SfImage>
         </div>
       </div>
     </div>
   </SfSection>
 </template>
 <script>
+import { addBasePath } from '@vue-storefront/core';
 import {
   SfSection,
   SfImage
@@ -38,6 +39,11 @@ export default {
   components: {
     SfSection,
     SfImage
+  },
+  setup() {
+    return {
+      addBasePath
+    };
   },
   computed: {
     ...mapMobileObserver()

--- a/packages/core/nuxt-theme-module/theme/components/LocaleSelector.vue
+++ b/packages/core/nuxt-theme-module/theme/components/LocaleSelector.vue
@@ -4,7 +4,7 @@
         class="container__lang container__lang--selected"
         @click="isLangModalOpen = !isLangModalOpen"
     >
-      <SfImage :src="`/icons/langs/${locale}.webp`" width="20" alt="Flag" />
+      <SfImage :src="addBasePath(`/icons/langs/${locale}.webp`)" width="20" alt="Flag" />
     </SfButton>
     <SfBottomModal
       :is-open="isLangModalOpen"
@@ -19,7 +19,7 @@
                 <span>{{ lang.label }}</span>
               </template>
               <template #icon>
-                <SfImage :src="`/icons/langs/${lang.code}.webp`" width="20" alt="Flag" class="language__flag" />
+                <SfImage :src="addBasePath(`/icons/langs/${lang.code}.webp`)" width="20" alt="Flag" class="language__flag" />
               </template>
             </SfCharacteristic>
           </a>
@@ -39,6 +39,7 @@ import {
   SfCharacteristic
 } from '@storefront-ui/vue';
 import { ref, computed } from '@nuxtjs/composition-api';
+import { addBasePath } from '@vue-storefront/core';
 export default {
   components: {
     SfImage,
@@ -55,7 +56,8 @@ export default {
     return {
       availableLocales,
       locale,
-      isLangModalOpen
+      isLangModalOpen,
+      addBasePath
     };
   }
 };

--- a/packages/core/nuxt-theme-module/theme/components/MobileStoreBanner.vue
+++ b/packages/core/nuxt-theme-module/theme/components/MobileStoreBanner.vue
@@ -1,6 +1,6 @@
 <template>
   <SfBanner
-    image="/homepage/bannerD.png"
+    :image="addBasePath('/homepage/bannerD.png')"
     subtitle="Fashon to take away"
     title="Download our application to your mobile"
     class="sf-banner--left desktop-only banner-app"
@@ -13,7 +13,7 @@
           @click="() => {}"
         >
           <SfImage
-            src="/homepage/apple.png"
+            :src="addBasePath('/homepage/apple.png')"
             alt="App store"
           />
         </SfButton>
@@ -23,7 +23,7 @@
           @click="() => {}"
         >
           <SfImage
-            src="/homepage/google.png"
+            :src="addBasePath('/homepage/google.png')"
             alt="Google play"
           />
         </SfButton>
@@ -37,12 +37,18 @@ import {
   SfImage,
   SfButton
 } from '@storefront-ui/vue';
+import { addBasePath } from '@vue-storefront/core';
 export default {
   name: 'AppStoreBanner',
   components: {
     SfBanner,
     SfImage,
     SfButton
+  },
+  setup() {
+    return {
+      addBasePath
+    };
   }
 };
 </script>

--- a/packages/core/nuxt-theme-module/theme/components/RelatedProducts.vue
+++ b/packages/core/nuxt-theme-module/theme/components/RelatedProducts.vue
@@ -8,7 +8,7 @@
         <SfCarouselItem class="carousel__item" v-for="(product, i) in products" :key="i">
           <SfProductCard
             :title="productGetters.getName(product)"
-            :image="product.images[0].url"
+            :image="addBasePath(product.images[0].url)"
             :regular-price="$n(productGetters.getFormattedPrice(productGetters.getPrice(product).regular), 'currency')"
             :special-price="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
             :max-rating="5"
@@ -36,6 +36,7 @@ import {
 } from '@storefront-ui/vue';
 import { productGetters, useWishlist, wishlistGetters, useCart } from '<%= options.generate.replace.composables %>';
 import { computed } from '@vue/composition-api';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'RelatedProducts',
@@ -64,7 +65,8 @@ export default {
       isInWishlist,
       removeProductFromWishlist,
       addItemToCart,
-      isInCart
+      isInCart,
+      addBasePath
     };
   }
 };

--- a/packages/core/nuxt-theme-module/theme/components/SearchResults.vue
+++ b/packages/core/nuxt-theme-module/theme/components/SearchResults.vue
@@ -42,7 +42,7 @@
                   :regular-price="$n(productGetters.getPrice(product).regular, 'currency')"
                   :score-rating="productGetters.getAverageRating(product)"
                   :reviews-count="7"
-                  :image="productGetters.getCoverImage(product)"
+                  :image="addBasePath(productGetters.getCoverImage(product))"
                   :alt="productGetters.getName(product)"
                   :title="productGetters.getName(product)"
                   :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
@@ -59,7 +59,7 @@
                 :regular-price="$n(productGetters.getPrice(product).regular, 'currency')"
                 :score-rating="productGetters.getAverageRating(product)"
                 :reviews-count="7"
-                :image="productGetters.getCoverImage(product)"
+                :image="addBasePath(productGetters.getCoverImage(product))"
                 :alt="productGetters.getName(product)"
                 :title="productGetters.getName(product)"
                 :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
@@ -73,7 +73,7 @@
           </div>
         </div>
         <div v-else key="no-results" class="before-results">
-          <SfImage src="/error/error.svg" class="before-results__picture" alt="error" loading="lazy"/>
+          <SfImage :src="addBasePath('/error/error.svg')" class="before-results__picture" alt="error" loading="lazy"/>
           <template v-if="term">
             <p class="before-results__paragraph">{{ $t('We haven’t found any results for given phrase') }}</p>
           </template>
@@ -100,6 +100,7 @@ import {
 } from '@storefront-ui/vue';
 import { ref, watch, computed } from '@nuxtjs/composition-api';
 import { useWishlist, wishlistGetters, productGetters } from '<%= options.generate.replace.composables %>';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'SearchResults',
@@ -155,7 +156,8 @@ export default {
       categories,
       addItemToWishlist,
       isInWishlist,
-      removeProductFromWishlist
+      removeProductFromWishlist,
+      addBasePath
     };
   }
 };

--- a/packages/core/nuxt-theme-module/theme/components/WishlistSidebar.vue
+++ b/packages/core/nuxt-theme-module/theme/components/WishlistSidebar.vue
@@ -23,7 +23,7 @@
               <SfCollectedProduct
                 v-for="product in products"
                 :key="wishlistGetters.getItemSku(product)"
-                :image="wishlistGetters.getItemImage(product)"
+                :image="addBasePath(wishlistGetters.getItemImage(product))"
                 :title="wishlistGetters.getItemName(product)"
                 :regular-price="$n(wishlistGetters.getItemPrice(product).regular, 'currency')"
                 :special-price="wishlistGetters.getItemPrice(product).special && $n(wishlistGetters.getItemPrice(product).special, 'currency')"
@@ -55,7 +55,7 @@
         </div>
         <div v-else class="empty-wishlist" key="empty-wishlist">
           <div class="empty-wishlist__banner">
-            <SfImage src="/icons/empty-cart.svg" alt="Empty bag" class="empty-wishlist__icon" />
+            <SfImage :src="addBasePath('/icons/empty-cart.svg')" alt="Empty bag" class="empty-wishlist__icon" />
             <SfHeading
               title="Your bag is empty"
               description="Looks like you haven’t added any items to the bag yet. Start
@@ -87,6 +87,7 @@ import {
 import { computed } from '@nuxtjs/composition-api';
 import { useWishlist, useUser, wishlistGetters } from '<%= options.generate.replace.composables %>';
 import { useUiState } from '~/composables';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'Wishlist',
@@ -109,6 +110,7 @@ export default {
     const totalItems = computed(() => wishlistGetters.getTotalItems(wishlist.value));
 
     return {
+      addBasePath,
       isAuthenticated,
       products,
       removeItem,

--- a/packages/core/nuxt-theme-module/theme/layouts/error.vue
+++ b/packages/core/nuxt-theme-module/theme/layouts/error.vue
@@ -2,7 +2,7 @@
   <div id="error">
     <SfImage
       class="image"
-      src="/error/error.svg"
+      :src="addBasePath('/error/error.svg')"
       alt="leaves"
     />
     <SfHeading
@@ -24,6 +24,7 @@
 <script>
 import { useRouter } from '@nuxtjs/composition-api';
 import { SfButton, SfImage, SfHeading } from '@storefront-ui/vue';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'ErrorLayout',
@@ -36,7 +37,8 @@ export default {
     const router = useRouter();
 
     return {
-      router
+      router,
+      addBasePath
     };
   }
 };

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -90,7 +90,7 @@
               :key="productGetters.getSlug(product)"
               :style="{ '--index': i }"
               :title="productGetters.getName(product)"
-              :image="productGetters.getCoverImage(product)"
+              :image="addBasePath(productGetters.getCoverImage(product))"
               :regular-price="$n(productGetters.getPrice(product).regular, 'currency')"
               :special-price="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
               :max-rating="5"
@@ -119,7 +119,7 @@
               :style="{ '--index': i }"
               :title="productGetters.getName(product)"
               :description="productGetters.getDescription(product)"
-              :image="productGetters.getCoverImage(product)"
+              :image="addBasePath(productGetters.getCoverImage(product))"
               :regular-price="$n(productGetters.getPrice(product).regular, 'currency')"
               :special-price="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
               :max-rating="5"
@@ -217,6 +217,7 @@ import { onSSR } from '@vue-storefront/core';
 import LazyHydrate from 'vue-lazy-hydration';
 import cacheControl from './../helpers/cacheControl';
 import CategoryPageHeader from '~/components/CategoryPageHeader';
+import { addBasePath } from '@vue-storefront/core';
 
 // TODO(addToCart qty, horizontal): https://github.com/vuestorefront/storefront-ui/issues/1606
 export default {
@@ -283,7 +284,8 @@ export default {
       isInWishlist,
       addToCart,
       isInCart,
-      productsQuantity
+      productsQuantity,
+      addBasePath
     };
   },
   components: {

--- a/packages/core/nuxt-theme-module/theme/pages/Checkout/Payment.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Checkout/Payment.vue
@@ -23,7 +23,7 @@
         class="table__row"
       >
         <SfTableData class="table__image">
-          <SfImage :src="cartGetters.getItemImage(product)" :alt="cartGetters.getItemName(product)" />
+          <SfImage :src="addBasePath(cartGetters.getItemImage(product))" :alt="cartGetters.getItemName(product)" />
         </SfTableData>
         <SfTableData class="table__data table__description table__data">
           <div class="product-title">{{ cartGetters.getItemName(product) }}</div>
@@ -111,6 +111,7 @@ import {
 import { onSSR } from '@vue-storefront/core';
 import { ref, computed, useRouter } from '@nuxtjs/composition-api';
 import { useMakeOrder, useCart, cartGetters, orderGetters } from '<%= options.generate.replace.composables %>';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'ReviewOrder',
@@ -148,6 +149,7 @@ export default {
     };
 
     return {
+      addBasePath,
       router,
       isPaymentReady,
       terms,

--- a/packages/core/nuxt-theme-module/theme/pages/Checkout/ThankYou.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Checkout/ThankYou.vue
@@ -5,8 +5,8 @@
       class="banner"
       title="Thank you for your order!"
       :image="{
-        mobile: '/thankyou/bannerM.png',
-        desktop: '/thankyou/bannerD.png',
+        mobile: addBasePath('/thankyou/bannerM.png'),
+        desktop: addBasePath('/thankyou/bannerD.png'),
       }"
     >
       <template #description>
@@ -79,6 +79,7 @@
 <script>
 import { SfHeading, SfButton, SfCallToAction } from '@storefront-ui/vue';
 import { ref } from '@nuxtjs/composition-api';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   components: {
@@ -98,6 +99,7 @@ export default {
     const orderNumber = ref('80932031-030-00');
 
     return {
+      addBasePath,
       companyDetails,
       orderNumber
     };

--- a/packages/core/nuxt-theme-module/theme/pages/Home.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Home.vue
@@ -78,7 +78,7 @@
         title="Subscribe to Newsletters"
         button-text="Subscribe"
         description="Be aware of upcoming sales and events. Receive gifts and special offers!"
-        image="/homepage/newsletter.webp"
+        :image="addBasePath('/homepage/newsletter.webp')"
         class="call-to-action"
       >
         <template #button>
@@ -123,6 +123,7 @@ import NewsletterModal from '~/components/NewsletterModal.vue';
 import LazyHydrate from 'vue-lazy-hydration';
 import { useUiState } from '../composables';
 import cacheControl from './../helpers/cacheControl';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'Home',
@@ -152,56 +153,56 @@ export default {
     const products = ref([
       {
         title: 'Cream Beach Bag',
-        image: '/homepage/productA.webp',
+        image: addBasePath('/homepage/productA.webp'),
         price: { regular: '50.00 $' },
         rating: { max: 5, score: 4 },
         isInWishlist: true
       },
       {
-        title: 'Cream Beach Bag',
-        image: '/homepage/productB.webp',
+        title: 'Cream Beach Bag 2',
+        image: addBasePath('/homepage/productB.webp'),
+        price: { regular: '50.00 $' },
+        rating: { max: 5, score: 4 },
+        isInWishlist: false
+      },
+      {
+        title: 'Cream Beach Bag 3',
+        image: addBasePath('/homepage/productC.webp'),
+        price: { regular: '50.00 $' },
+        rating: { max: 5, score: 4 },
+        isInWishlist: false
+      },
+      {
+        title: 'Cream Beach Bag RR',
+        image: addBasePath('/homepage/productA.webp'),
         price: { regular: '50.00 $' },
         rating: { max: 5, score: 4 },
         isInWishlist: false
       },
       {
         title: 'Cream Beach Bag',
-        image: '/homepage/productC.webp',
+        image: addBasePath('/homepage/productB.webp'),
         price: { regular: '50.00 $' },
         rating: { max: 5, score: 4 },
         isInWishlist: false
       },
       {
         title: 'Cream Beach Bag',
-        image: '/homepage/productA.webp',
+        image: addBasePath('/homepage/productC.webp'),
         price: { regular: '50.00 $' },
         rating: { max: 5, score: 4 },
         isInWishlist: false
       },
       {
         title: 'Cream Beach Bag',
-        image: '/homepage/productB.webp',
+        image: addBasePath('/homepage/productA.webp'),
         price: { regular: '50.00 $' },
         rating: { max: 5, score: 4 },
         isInWishlist: false
       },
       {
         title: 'Cream Beach Bag',
-        image: '/homepage/productC.webp',
-        price: { regular: '50.00 $' },
-        rating: { max: 5, score: 4 },
-        isInWishlist: false
-      },
-      {
-        title: 'Cream Beach Bag',
-        image: '/homepage/productA.webp',
-        price: { regular: '50.00 $' },
-        rating: { max: 5, score: 4 },
-        isInWishlist: false
-      },
-      {
-        title: 'Cream Beach Bag',
-        image: '/homepage/productB.webp',
+        image: addBasePath('/homepage/productB.webp'),
         price: { regular: '50.00 $' },
         rating: { max: 5, score: 4 },
         isInWishlist: false
@@ -212,13 +213,13 @@ export default {
         title: 'Colorful summer dresses are already in store',
         subtitle: 'SUMMER COLLECTION 2019',
         background: '#eceff1',
-        image: '/homepage/bannerH.webp'
+        image: addBasePath('/homepage/bannerH.webp')
       },
       {
         title: 'Colorful summer dresses are already in store',
         subtitle: 'SUMMER COLLECTION 2019',
         background: '#efebe9',
-        image: '/homepage/bannerA.webp',
+        image: addBasePath('/homepage/bannerA.webp'),
         className:
           'sf-hero-item--position-bg-top-left sf-hero-item--align-right'
       },
@@ -226,7 +227,7 @@ export default {
         title: 'Colorful summer dresses are already in store',
         subtitle: 'SUMMER COLLECTION 2019',
         background: '#fce4ec',
-        image: '/homepage/bannerB.webp'
+        image: addBasePath('/homepage/bannerB.webp')
       }
     ];
     const banners = [
@@ -238,8 +239,8 @@ export default {
           'Find stunning women\'s cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands.',
         buttonText: 'Shop now',
         image: {
-          mobile: $config.theme.home.bannerA.image.mobile,
-          desktop: $config.theme.home.bannerA.image.desktop
+          mobile: addBasePath($config.theme.home.bannerA.image.mobile),
+          desktop: addBasePath($config.theme.home.bannerA.image.desktop)
         },
         class: 'sf-banner--slim desktop-only',
         link: $config.theme.home.bannerA.link
@@ -251,7 +252,7 @@ export default {
         description:
           'Find stunning women\'s cocktail dresses and party dresses. Stand out in lace and metallic cocktail dresses from all your favorite brands.',
         buttonText: 'Shop now',
-        image: $config.theme.home.bannerB.image,
+        image: addBasePath($config.theme.home.bannerB.image),
         class: 'sf-banner--slim banner-central desktop-only',
         link: $config.theme.home.bannerB.link
       },
@@ -259,7 +260,7 @@ export default {
         slot: 'banner-C',
         subtitle: 'T-Shirts',
         title: 'The Office Life',
-        image: $config.theme.home.bannerC.image,
+        image: addBasePath($config.theme.home.bannerC.image),
         class: 'sf-banner--slim banner__tshirt',
         link: $config.theme.home.bannerC.link
       },
@@ -267,7 +268,7 @@ export default {
         slot: 'banner-D',
         subtitle: 'Summer Sandals',
         title: 'Eco Sandals',
-        image: $config.theme.home.bannerD.image,
+        image: addBasePath($config.theme.home.bannerD.image),
         class: 'sf-banner--slim',
         link: $config.theme.home.bannerD.link
       }
@@ -286,6 +287,7 @@ export default {
       toggleWishlist,
       toggleNewsletterModal,
       onSubscribe,
+      addBasePath,
       banners,
       heroes,
       products

--- a/packages/core/nuxt-theme-module/theme/pages/Product.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Product.vue
@@ -185,6 +185,7 @@ import { useProduct, useCart, productGetters, useReview, reviewGetters } from '<
 import { onSSR } from '@vue-storefront/core';
 import LazyHydrate from 'vue-lazy-hydration';
 import cacheControl from './../helpers/cacheControl';
+import { addBasePath } from '@vue-storefront/core';
 
 export default {
   name: 'Product',
@@ -212,9 +213,9 @@ export default {
     // TODO: Breadcrumbs are temporary disabled because productGetters return undefined. We have a mocks in data
     // const breadcrumbs = computed(() => productGetters.getBreadcrumbs ? productGetters.getBreadcrumbs(product.value) : props.fallbackBreadcrumbs);
     const productGallery = computed(() => productGetters.getGallery(product.value).map(img => ({
-      mobile: { url: img.small },
-      desktop: { url: img.normal },
-      big: { url: img.big },
+      mobile: { url: addBasePath(img.small) },
+      desktop: { url: addBasePath(img.normal) },
+      big: { url: addBasePath(img.big) },
       alt: product.value._name || product.value.name
     })));
 


### PR DESCRIPTION
Pass base path configured as a router: {base: ... to axios and provide helper that adds base path to images.

## Description
It enables developers to change router.base value

## Related Issue
https://vsf.atlassian.net/browse/OS-203

## Motivation and Context
When developer want to change router.base there was problem with api calls and redirection/not working images.

## How Has This Been Tested?
Manual tests on commercetools build

## Screenshots:
<!-- if appropriate, and if you made any changes in the UI layer please provide before/after screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!-- VSF 1 only -->
> I tested manually my code, and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

