### PR TITLE
chore: update spree integration status in docs

### DIFF
--- a/packages/core/docs/.vuepress/integrations.js
+++ b/packages/core/docs/.vuepress/integrations.js
@@ -158,7 +158,7 @@ const INTEGRATIONS = {
       name: 'SpreeCommerce',
       link: 'https://docs.vuestorefront.io/spree/',
       image: '/v2/integrations-logos/spree.svg',
-      status: STATUSES.BETA,
+      status: STATUSES.STABLE,
       availability: AVAILABILITY.OPEN_SOURCE,
       maintainedBy: [
         { name: 'Upside Lab', link: 'https://upsidelab.io/' }


### PR DESCRIPTION
We've finished testing of the Spree integration and we've just release the stable v1.0
@bloodf per our discussion, I'm creating a PR here

## Description
This PR changes the badge next to Spree integration in the docs.

## Related Issue
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

#### Code standards
- [x] My code follows the code style of this project.

#### Docs
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

