### PR TITLE
fix(core): allow disabling locale redirects

### DIFF
--- a/packages/boilerplate/theme/nuxt.config.js
+++ b/packages/boilerplate/theme/nuxt.config.js
@@ -121,7 +121,9 @@ export default {
         }
       }
     },
-    detectBrowserLanguage: false
+    detectBrowserLanguage: {
+      useCookie: false
+    }
   },
 
   styleResources: {

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -116,7 +116,9 @@ export default {
         }
       }
     },
-    detectBrowserLanguage: false
+    detectBrowserLanguage: {
+      useCookie: false
+    }
   },
   styleResources: {
     scss: [require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] })]

--- a/packages/core/docs/changelog/6551.js
+++ b/packages/core/docs/changelog/6551.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'fix(core): allow disabling locale redirects',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6551',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Łukasz Śliwa',
+  linkToGitHubAccount: 'https://github.com/lsliwaradioluz'
+};

--- a/packages/core/docs/migrate/2.5.0/overview.md
+++ b/packages/core/docs/migrate/2.5.0/overview.md
@@ -119,7 +119,9 @@ Follow the steps below to upgrade your existing projects:
     //nuxt.config.js
     export default {
       i18n: {
-        detectBrowserLanguage: false
+        detectBrowserLanguage: {
+          useCookie: false
+        }
       }
     };
     ```

--- a/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
+++ b/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
@@ -40,7 +40,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
       [cookieNames.currency]: getCurrencyByLocale(targetLocale)
     };
 
-    if (redirectPath) {
+    if (redirectPath && i18nOptions.detectBrowserLanguage) {
       redirect(redirectPath);
     }
 


### PR DESCRIPTION
## Description
I think it would be a good idea to leave the door open for preventing locale redirects in vsf applications.

Last month we overwrote the default `i18n` locale redirects logic in the `i18nCookiesPlugin`. It detects the browser locale and redirects to it unconditionally (provided that it's one of the locales available in the VSF application). It happens even if the `detectBrowserLanguage` option is set to `false`.

My proposition here is to give our customers the ability to prevent redirects by setting the `detectBrowserLanguage` to `false`. And - to prevent generating the cookies by the `i18n` library - use the following configuration:

```
i18n: {
    detectBrowserLanguage: {
      useCookie: false
    }
}
```

It's the approach suggested by the nuxt-i18n [documentation](https://i18n.nuxtjs.org/browser-language-detection/):
![image](https://user-images.githubusercontent.com/39009379/144760420-7a614207-11e1-4a20-a506-6f75e75cd778.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [z] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!-- VSF 1 only -->
> I tested manually my code, and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme

#### Code standards
- [ ] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

