### PR TITLE
fix: loading integrations in Server Middleware

### DIFF
--- a/packages/core/docs/changelog/6567.js
+++ b/packages/core/docs/changelog/6567.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Fix loading integrations in Server Middleware',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6567',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Filip Sobol',
+  linkToGitHubAccount: 'https://github.com/filipsobol'
+};


### PR DESCRIPTION
This PR fixes loading of the integrations defined in the `middleware.config.js`. Instead of resolving integrations from the path relative to the package, it resolves them based on the current working directory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.

#### Changelog
- [X] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [X] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Code standards
- [X] My code follows the code style of this project.
- [X] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

