### PR TITLE
refactor(nuxt-module): added `autoChangeCookie` option to nuxt config

### DIFF
--- a/packages/core/docs/changelog/6578.js
+++ b/packages/core/docs/changelog/6578.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Add the `autoChangeCookie` option on nuxt-i18n configuration to handle fine control on cookie',
+  link: '',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Heitor Ramon',
+  linkToGitHubAccount: 'https://github.com/bloodf'
+};

--- a/packages/core/docs/getting-started/internationalization.md
+++ b/packages/core/docs/getting-started/internationalization.md
@@ -84,3 +84,42 @@ You can provide your own i18n configuration just for a specific module by settin
   },
 ];
 ```
+
+## Configuring the Auto Cookie Change
+You can control how the `@vue-storefront/nuxt` module will handle the cookies under the hood. This configuration will allow you to manage the fine control on the cookie changes after each locale changes.
+
+The `autoChangeCookie` object holds three new properties, that are direct linked to `currency`, `locale`, and `country`. Those properties control how the module will handle the cookie changes. If set to `false`, the module won't change automatically any cookie based on configurations or browser locale, so the `{INTEGARTION}` will handle that.
+
+```js
+[
+  '@vue-storefront/{INTEGRATION}/nuxt',
+  {
+    api: {
+      // api client configuration
+    },
+    i18n: {
+      useNuxtI18nModule: false,
+      locales: [
+        {
+          code: 'en',
+          label: 'English',
+          file: 'en.js',
+          iso: 'en',
+        },
+        {
+          code: 'de',
+          label: 'German',
+          file: 'de.js',
+          iso: 'de',
+        },
+      ],
+      defaultLocale: 'en',
+      autoChangeCookie: {
+        currency: false,
+        locale: false,
+        country: false,
+      },
+    },
+  },
+];
+```

--- a/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
+++ b/packages/core/nuxt-module/lib/plugins/i18n-cookies.js
@@ -13,6 +13,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   }
   const cookieLocale = $cookies.get(cookieNames.locale);
   const cookieCurrency = $cookies.get(cookieNames.currency);
+  const cookieCountry = $cookies.get(cookieNames.country);
 
   const getCurrencyByLocale = (locale) =>
     i18n.numberFormats?.[locale]?.currency?.currency
@@ -69,20 +70,24 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   if (missingFields.length) {
     throw new Error(`Following fields are missing in the i18n configuration: ${missingFields.join(', ')}`);
   }
-
-  if (cookieLocale !== settings.locale) {
+  if (cookieLocale !== settings.locale && !!i18nOptions.autoChangeCookie?.locale || !$cookies.get(cookieNames.locale)) {
     $cookies.set(cookieNames.locale, settings.locale, cookieOptions);
   }
 
-  if (cookieCurrency !== settings.currency) {
+  if (cookieCurrency !== settings.currency && !!i18nOptions.autoChangeCookie?.currency || !$cookies.get(cookieNames.currency)) {
     $cookies.set(cookieNames.currency, settings.currency, cookieOptions);
   }
 
-  !$cookies.get(cookieNames.country) && $cookies.set(cookieNames.country, settings.country, cookieOptions);
-
+  if(cookieCountry !== settings.country && !!i18nOptions.autoChangeCookie?.country || !$cookies.get(cookieNames.country)){
+    $cookies.set(cookieNames.country, settings.country, cookieOptions);
+  }
   i18n.onBeforeLanguageSwitch = (oldLocale, newLocale, isInitialSetup, context) => {
-    $cookies.set(cookieNames.locale, newLocale, cookieOptions);
-    $cookies.set(cookieNames.currency, getCurrencyByLocale(newLocale), cookieOptions);
+    if(!!i18nOptions.autoChangeCookie?.locale){
+      $cookies.set(cookieNames.locale, newLocale, cookieOptions);
+    }
+    if(!!i18nOptions.autoChangeCookie?.currency){
+      $cookies.set(cookieNames.currency, getCurrencyByLocale(newLocale), cookieOptions);
+    }
     window.location.href = context.route.fullPath;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This enables the possibility to control how the i18n plugin handles the cookies, so integrators can also control more finite cookies without the plugin handling for them.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- For example closes #123  -->
<!--- Please link to the issue here: -->

## Motivation and Context
When creating the Magento integration, we want to control each step of the process, like currency and country without the need for the module to handle that automatically. 

## How Has This Been Tested?
Locally tested

## Screenshots:
<!-- if appropriate, and if you made any changes in the UI layer please provide before/after screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!-- VSF 1 only -->
> I tested manually my code, and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

