### PR TITLE
feat: support for slash-containing locales in i18n

### DIFF
--- a/packages/core/core/__tests__/utils/i18n-redirects.spec.ts
+++ b/packages/core/core/__tests__/utils/i18n-redirects.spec.ts
@@ -3,16 +3,16 @@ import i18nRedirectsUtil from '../../src/utils/i18n-redirects';
 const defaultParams = {
   path: '/',
   defaultLocale: 'en',
-  availableLocales: ['en', 'de'],
+  availableLocales: ['ch/de', 'en', 'de'],
   cookieLocale: '',
-  acceptedLanguages: ['de', 'en']
+  acceptedLanguages: ['ch/de', 'en', 'de']
 };
 
 describe('i18n redirects util', () => {
   it('returns redirect path for the first visit with not default locale accepted', async () => {
     const util = i18nRedirectsUtil(defaultParams);
 
-    expect(util.getRedirectPath()).toEqual('/de');
+    expect(util.getRedirectPath()).toEqual('/ch/de');
   });
 
   it('returns redirect path for the first visit with default locale accepted', async () => {
@@ -27,10 +27,10 @@ describe('i18n redirects util', () => {
   it('returns redirect path for page with default locale and with cookie set to other locale', async () => {
     const util = i18nRedirectsUtil({
       ...defaultParams,
-      cookieLocale: 'de'
+      cookieLocale: 'ch/de'
     });
 
-    expect(util.getRedirectPath()).toEqual('/de');
+    expect(util.getRedirectPath()).toEqual('/ch/de');
   });
 
   it('returns no redirect path for page with locale and with cookie set to other locale', async () => {
@@ -46,7 +46,7 @@ describe('i18n redirects util', () => {
   it('returns no redirect for page with locale and without cookie with locale', async () => {
     const util = i18nRedirectsUtil({
       ...defaultParams,
-      path: '/de'
+      path: '/ch/de'
     });
 
     expect(util.getRedirectPath()).toEqual('');
@@ -54,7 +54,7 @@ describe('i18n redirects util', () => {
 
   it('returns full redirect path properly', async () => {
     const path = '/c/men?foo=bar#foo';
-    const cookieLocale = 'de';
+    const cookieLocale = 'ch/de';
     const util = i18nRedirectsUtil({
       ...defaultParams,
       path,
@@ -76,10 +76,10 @@ describe('i18n redirects util', () => {
   it('returns target locale based on cookie', async () => {
     const util = i18nRedirectsUtil({
       ...defaultParams,
-      cookieLocale: 'de'
+      cookieLocale: 'ch/de'
     });
 
-    expect(util.getTargetLocale()).toEqual('de');
+    expect(util.getTargetLocale()).toEqual('ch/de');
   });
 
   it('returns target locale based on accepted languages', async () => {
@@ -87,7 +87,7 @@ describe('i18n redirects util', () => {
       ...defaultParams
     });
 
-    expect(util.getTargetLocale()).toEqual('de');
+    expect(util.getTargetLocale()).toEqual('ch/de');
   });
 
   it('returns default target locale', async () => {
@@ -97,5 +97,14 @@ describe('i18n redirects util', () => {
     });
 
     expect(util.getTargetLocale()).toEqual('en');
+  });
+
+  it('returns a precise locale match from path', async () => {
+    const util = i18nRedirectsUtil({
+      ...defaultParams,
+      path: '/endangered'
+    });
+
+    expect(util.getTargetLocale()).toEqual('ch/de');
   });
 });

--- a/packages/core/core/__tests__/utils/i18n-redirects.spec.ts
+++ b/packages/core/core/__tests__/utils/i18n-redirects.spec.ts
@@ -9,102 +9,115 @@ const defaultParams = {
 };
 
 describe('i18n redirects util', () => {
-  it('returns redirect path for the first visit with not default locale accepted', async () => {
-    const util = i18nRedirectsUtil(defaultParams);
+  describe('getRedirectPath()', () => {
+    it('returns redirect path for the first visit with not default locale accepted', async () => {
+      const util = i18nRedirectsUtil(defaultParams);
 
-    expect(util.getRedirectPath()).toEqual('/ch/de');
-  });
-
-  it('returns redirect path for the first visit with default locale accepted', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      acceptedLanguages: ['en']
+      expect(util.getRedirectPath()).toEqual('/ch/de');
     });
 
-    expect(util.getRedirectPath()).toEqual('');
-  });
+    it('returns redirect path for the first visit with default locale accepted', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        acceptedLanguages: ['en']
+      });
 
-  it('returns redirect path for page with default locale and with cookie set to other locale', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      cookieLocale: 'ch/de'
+      expect(util.getRedirectPath()).toEqual('');
     });
 
-    expect(util.getRedirectPath()).toEqual('/ch/de');
-  });
+    it('returns redirect path for page with default locale and with cookie set to other locale', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        cookieLocale: 'ch/de'
+      });
 
-  it('returns no redirect path for page with locale and with cookie set to other locale', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      path: '/de',
-      cookieLocale: 'en'
+      expect(util.getRedirectPath()).toEqual('/ch/de');
     });
 
-    expect(util.getRedirectPath()).toEqual('');
-  });
+    it('returns no redirect path for page with locale and with cookie set to other locale', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        path: '/de',
+        cookieLocale: 'en'
+      });
 
-  it('returns no redirect for page with locale and without cookie with locale', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      path: '/ch/de'
+      expect(util.getRedirectPath()).toEqual('');
     });
 
-    expect(util.getRedirectPath()).toEqual('');
-  });
+    it('returns no redirect for page with locale and without cookie with locale', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        path: '/ch/de'
+      });
 
-  it('returns full redirect path properly', async () => {
-    const path = '/c/men?foo=bar#foo';
-    const cookieLocale = 'ch/de';
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      path,
-      cookieLocale
+      expect(util.getRedirectPath()).toEqual('');
     });
 
-    expect(util.getRedirectPath()).toEqual(`/${cookieLocale}${path}`);
+    it('returns full redirect path properly', async () => {
+      const path = '/c/men?foo=bar#foo';
+      const cookieLocale = 'ch/de';
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        path,
+        cookieLocale
+      });
+
+      expect(util.getRedirectPath()).toEqual(`/${cookieLocale}${path}`);
+    });
   });
 
-  it('returns target locale based on path', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      path: '/de'
+  describe('getTargetLocale()', () => {
+    it('returns target locale based on path', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        path: '/de'
+      });
+
+      expect(util.getTargetLocale()).toEqual('de');
     });
 
-    expect(util.getTargetLocale()).toEqual('de');
-  });
+    it('returns target locale based on cookie', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        cookieLocale: 'ch/de'
+      });
 
-  it('returns target locale based on cookie', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      cookieLocale: 'ch/de'
+      expect(util.getTargetLocale()).toEqual('ch/de');
     });
 
-    expect(util.getTargetLocale()).toEqual('ch/de');
-  });
+    it('returns target locale based on accepted languages', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams
+      });
 
-  it('returns target locale based on accepted languages', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams
+      expect(util.getTargetLocale()).toEqual('ch/de');
     });
 
-    expect(util.getTargetLocale()).toEqual('ch/de');
-  });
+    it('returns default target locale', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        acceptedLanguages: ['es', 'en']
+      });
 
-  it('returns default target locale', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      acceptedLanguages: ['es', 'en']
+      expect(util.getTargetLocale()).toEqual('en');
     });
 
-    expect(util.getTargetLocale()).toEqual('en');
-  });
+    it('does not pick a locale from random words at the start of a path', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        path: '/endangered'
+      });
 
-  it('returns a precise locale match from path', async () => {
-    const util = i18nRedirectsUtil({
-      ...defaultParams,
-      path: '/endangered'
+      expect(util.getTargetLocale()).toEqual('ch/de');
     });
 
-    expect(util.getTargetLocale()).toEqual('ch/de');
+    it('does not pick a locale from random words in the middle of a path', async () => {
+      const util = i18nRedirectsUtil({
+        ...defaultParams,
+        path: '/c/men'
+      });
+
+      expect(util.getTargetLocale()).toEqual('ch/de');
+    });
   });
 });

--- a/packages/core/core/src/utils/i18n-redirects/index.ts
+++ b/packages/core/core/src/utils/i18n-redirects/index.ts
@@ -14,8 +14,8 @@ const i18nRedirectsUtil = ({
   getRedirectPath: () => string;
   getTargetLocale: () => string;
 } => {
-  const localeRegexp = new RegExp(`(?<=/)(${availableLocales.join('|')})(?=(/|$))`, 'g');
-  const localeFromPath = path.match(localeRegexp) && path.match(localeRegexp)[0];
+  const localeRegexp = new RegExp(`^/(?<locale>${availableLocales.join('|')})(?=(/|$))`, 'g');
+  const localeFromPath = localeRegexp.exec(path)?.groups.locale;
   const strippedLocaleFromPath = path.replace(`/${localeFromPath}`, '');
   const removeTailingSlash = (path: string): string => path.replace(/\/$/, '');
   const getTargetLocale = (): string => {

--- a/packages/core/core/src/utils/i18n-redirects/index.ts
+++ b/packages/core/core/src/utils/i18n-redirects/index.ts
@@ -14,7 +14,7 @@ const i18nRedirectsUtil = ({
   getRedirectPath: () => string;
   getTargetLocale: () => string;
 } => {
-  const localeRegexp = new RegExp(`(${availableLocales.join('|')})(?=(/|$))`, 'g');
+  const localeRegexp = new RegExp(`(?<=/)(${availableLocales.join('|')})(?=(/|$))`, 'g');
   const localeFromPath = path.match(localeRegexp) && path.match(localeRegexp)[0];
   const strippedLocaleFromPath = path.replace(`/${localeFromPath}`, '');
   const removeTailingSlash = (path: string): string => path.replace(/\/$/, '');

--- a/packages/core/core/src/utils/i18n-redirects/index.ts
+++ b/packages/core/core/src/utils/i18n-redirects/index.ts
@@ -14,13 +14,9 @@ const i18nRedirectsUtil = ({
   getRedirectPath: () => string;
   getTargetLocale: () => string;
 } => {
-  const arrayFromPath = path.split('/').filter(String);
-  const localeCandidate = arrayFromPath[0];
-  const isLocaleAvailable = (locale: string): boolean => availableLocales.includes(locale);
-  const strippedLocaleFromPath = isLocaleAvailable(localeCandidate) ? `/${arrayFromPath.slice(1).join('/')}` : path;
-  const localeFromPath = isLocaleAvailable(localeCandidate) ? localeCandidate : '';
+  const localeFromPath = availableLocales.find(locale => path.includes('/' + locale));
+  const strippedLocaleFromPath = path.replace(localeFromPath, '');
   const removeTailingSlash = (path: string): string => path.replace(/\/$/, '');
-
   const getTargetLocale = (): string => {
     const languagesOrderedByPriority = [
       localeFromPath,
@@ -29,7 +25,7 @@ const i18nRedirectsUtil = ({
       defaultLocale
     ];
 
-    return languagesOrderedByPriority.find(code => isLocaleAvailable(code));
+    return languagesOrderedByPriority.find(code => availableLocales.includes(code));
   };
 
   const getRedirectPath = (): string => {

--- a/packages/core/core/src/utils/i18n-redirects/index.ts
+++ b/packages/core/core/src/utils/i18n-redirects/index.ts
@@ -14,8 +14,9 @@ const i18nRedirectsUtil = ({
   getRedirectPath: () => string;
   getTargetLocale: () => string;
 } => {
-  const localeFromPath = availableLocales.find(locale => path.includes('/' + locale));
-  const strippedLocaleFromPath = path.replace(localeFromPath, '');
+  const localeRegexp = new RegExp(`(${availableLocales.join('|')})(?=(/|$))`, 'g');
+  const localeFromPath = path.match(localeRegexp) && path.match(localeRegexp)[0];
+  const strippedLocaleFromPath = path.replace(`/${localeFromPath}`, '');
   const removeTailingSlash = (path: string): string => path.replace(/\/$/, '');
   const getTargetLocale = (): string => {
     const languagesOrderedByPriority = [


### PR DESCRIPTION
## Description
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Currently our `i18n` logic does not support locale codes that include a slash, i.e. `us/en`. Creating a routing structure following the `<country>/<language>` pattern results in endless redirects and other incorrect behaviours.

I've refactored our `i18nRedirectsUtil` so that they handle that type of locales correctly.

## How Has This Been Tested?
This has been tested by updating the existing unit tests and adding new ones. It has also been tested manually on a fresh project generated from the cli.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [x] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)
