### PR TITLE
fix: disable cache when not used

### DIFF
--- a/packages/core/cache/__tests__/useCache.spec.ts
+++ b/packages/core/cache/__tests__/useCache.spec.ts
@@ -38,6 +38,7 @@ describe('useCache', () => {
       return {
         req: {
           $vsfCache: {
+            enabled: true,
             tagsSet: new Set()
           }
         }
@@ -53,6 +54,7 @@ describe('useCache', () => {
     useContextMock.mockImplementation(() => ({
       req: {
         $vsfCache: {
+          enabled: true,
           tagsSet: new Set()
         }
       }
@@ -69,6 +71,7 @@ describe('useCache', () => {
     useContextMock.mockImplementation(() => ({
       req: {
         $vsfCache: {
+          enabled: true,
           tagsSet: new Set()
         }
       }
@@ -86,6 +89,7 @@ describe('useCache', () => {
     useContextMock.mockImplementation(() => ({
       req: {
         $vsfCache: {
+          enabled: true,
           tagsSet: new Set()
         }
       }

--- a/packages/core/cache/src/composables/useCache.ts
+++ b/packages/core/cache/src/composables/useCache.ts
@@ -5,13 +5,12 @@ export const useCache = (): UseCache => {
   const { req }: any = useContext();
   const isCacheEnabled = req && req.$vsfCache ? req.$vsfCache?.enabled : false;
 
-
   if (!req || !isCacheEnabled) {
     return {
       addTags: () => {},
       clearTags: () => {},
       getTags: () => [],
-      setTags: () => {},
+      setTags: () => {}
     };
   }
 

--- a/packages/core/cache/src/composables/useCache.ts
+++ b/packages/core/cache/src/composables/useCache.ts
@@ -3,13 +3,15 @@ import { useContext } from '@nuxtjs/composition-api';
 
 export const useCache = (): UseCache => {
   const { req }: any = useContext();
+  const isCacheEnabled = req && req.$vsfCache ? req.$vsfCache?.enabled : false;
 
-  if (!req) {
+
+  if (!req || !isCacheEnabled) {
     return {
       addTags: () => {},
       clearTags: () => {},
       getTags: () => [],
-      setTags: () => {}
+      setTags: () => {},
     };
   }
 


### PR DESCRIPTION
This ensures that cache is enabled before going to cache.

## Description
with this, app doesn't break when there are uses useCache in theme, because it will return early
