### PR TITLE
chore: add dependabot config file

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,3 +1,4 @@
+version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,8 @@
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Because we mainly do development on the `develop` branch, I added a dependabot configuration file to make it do dependency scanning against that branch.