### PR TITLE
chore: fix labeler

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,13 +6,15 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request]
+on:
+- pull_request_target
 
 jobs:
   label:
-
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/labeler@master
       with:


### PR DESCRIPTION
Currently, labeler doesn't work on PRs made from forks, meaning that any community contributions will not have labels. This issue is caused by how the `pull_request` trigger works.

Some time ago, GitHub added a new `pull_request_target` trigger that can safely run Actions against forks, assuming proper configuration.

I updated the workflow to match the example from the official GitHub's [actions/labeler](https://github.com/actions/labeler#create-workflow) repository.

You should not use this trigger for other Actions unless you are absolutely sure it's safe. Otherwise, you can leak the `GITHUB_TOKEN`. Refer to the [pull_request_target documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) for more information.