### PR TITLE
feat(core): configurable cookie attributes

### DIFF
--- a/packages/core/docs/changelog/6715.js
+++ b/packages/core/docs/changelog/6715.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Add option to configure locale, currency and country cookie attributes for the i18nCookiesPlugin',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6715',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Marcin Sulowski',
+  linkToGitHubAccount: 'https://github.com/MarcinSulowski'
+};

--- a/packages/core/docs/getting-started/internationalization.md
+++ b/packages/core/docs/getting-started/internationalization.md
@@ -131,12 +131,15 @@ You can overwrite the default `currency`, `locale`, and `country` cookie attribu
 
 ```js
 // nuxt.config.js
-i18n: {
-  cookieOptions: {
-    // default attributes used by the `@vue-storefront/nuxt` module
-    path: '/',
-    sameSite: 'lax',
-    expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
+
+export default {
+  i18n: {
+    cookieOptions: {
+      // default attributes used by the `@vue-storefront/nuxt` module
+      path: '/',
+      sameSite: 'lax',
+      expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
+    }
   }
 }
 ```

--- a/packages/core/docs/getting-started/internationalization.md
+++ b/packages/core/docs/getting-started/internationalization.md
@@ -126,7 +126,8 @@ modules: [
 }
 ```
 ## Configuring cookie attributes
-You can overwrite the default `currency`, `locale`, and `country` cookie attributes set by the `@vue-storefront/nuxt` module and add new ones. Simply create a new `cookieOptions` object for the `i18n` configuration object in the `nuxt.config.js` file and specify the attributes you'd like the cookies to hold.
+
+You can overwrite the default `currency`, `locale`, and `country` cookie attributes set by the `@vue-storefront/nuxt` module or add new ones. Create a new `cookieOptions` object for the `i18n` configuration object in the `nuxt.config.js` file and specify the attributes you'd like the cookies to have.
 
 ```js
 // nuxt.config.js

--- a/packages/core/docs/getting-started/internationalization.md
+++ b/packages/core/docs/getting-started/internationalization.md
@@ -125,3 +125,17 @@ modules: [
   },
 }
 ```
+## Configuring cookie attributes
+You can overwrite the default `currency`, `locale`, and `country` cookie attributes set by the `@vue-storefront/nuxt` module and add new ones. Simply create a new `cookieOptions` object for the `i18n` configuration object in the `nuxt.config.js` file and specify the attributes you'd like the cookies to hold.
+
+```js
+// nuxt.config.js
+i18n: {
+  cookieOptions: {
+    // default attributes used by the `@vue-storefront/nuxt` module
+    path: '/',
+    sameSite: 'lax',
+    expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
+  }
+}
+```

--- a/packages/core/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/core/nuxt-module/plugins/i18n-cookies.js
@@ -56,7 +56,8 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   const cookieOptions = {
     path: '/',
     sameSite: 'lax',
-    expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)) // Year from now
+    expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)), // Year from now
+    ...i18nOptions.cookieOptions
   };
   const settings = {
     locale: targetLocale,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes it possible to overwrite the default attributes and create new ones for the locale, country and currency cookies.

## Related Issue
[CORE-6](https://vsf.atlassian.net/browse/CORE-6)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This supports the use case where you have to set cookies on a parent domain to support differing subdomains for different sections of the website (setting the `domain` attribute for cookies). Additionally, you can overwrite the existing attributes or set new ones, if need be.

## How Has This Been Tested?
Tested locally with the commercetools integration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

