### PR TITLE
fix(core): add option to disable the locale auto-redirect in i18n-cookies plugin

### DIFF
--- a/packages/core/docs/changelog/6717.js
+++ b/packages/core/docs/changelog/6717.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Add option to disable the automatic locale redirect of the i18nCookiesPlugin',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6717',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Marcin Sulowski',
+  linkToGitHubAccount: 'https://github.com/MarcinSulowski'
+};

--- a/packages/core/docs/getting-started/internationalization.md
+++ b/packages/core/docs/getting-started/internationalization.md
@@ -143,3 +143,16 @@ export default {
   }
 }
 ```
+## Disabling the auto-redirect mechanism
+
+You can disable the auto-redirect mechanism of the `@vue-storefront/nuxt` module. The mechanism performs an automatic server-side redirect to a url created based on the target locale. To disable it set the `autoRedirectByLocale` to `false` in the `i18n` configuration object in your `nuxt.config.js`.
+
+```js
+// nuxt.config.js
+
+export default {
+  i18n: {
+    autoRedirectByLocale: false
+  }
+}
+```

--- a/packages/core/docs/getting-started/internationalization.md
+++ b/packages/core/docs/getting-started/internationalization.md
@@ -152,6 +152,7 @@ You can disable the auto-redirect mechanism of the `@vue-storefront/nuxt` module
 
 export default {
   i18n: {
+    // ...defaultConfig
     autoRedirectByLocale: false
   }
 }

--- a/packages/core/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/core/nuxt-module/plugins/i18n-cookies.js
@@ -6,6 +6,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   const navigator = isServer ? undefined : window.navigator;
   const acceptedLanguage = app.context.req?.headers?.['accept-language'] || navigator?.languages || '';
   const isRouteValid = !!app.context.route.name;
+  const autoRedirectByLocale = i18nOptions.autoRedirectByLocale ?? true;
   const cookieNames = {
     currency: i18nOptions.cookies?.currencyCookieName || VSF_CURRENCY_COOKIE,
     country: i18nOptions.cookies?.countryCookieName || VSF_COUNTRY_COOKIE,
@@ -47,7 +48,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
       ...(autoChangeCookie.currency && { [cookieNames.currency]: getCurrencyByLocale(targetLocale) })
     };
 
-    if (redirectPath) {
+    if (autoRedirectByLocale && redirectPath) {
       redirect(redirectPath);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added `autoRedirectByLocale` option in the i18n configuration object in nuxt.config.js to allow for bypassing the auto-redirect mechanism of the i18n-cookies plugin.

## Related Issue
[CT-192](https://vsf.atlassian.net/browse/CT-192)

## Motivation and Context
Fixes a scenario in which personal language preference set for a user's browser is different than the default locale (e.g. browser prefers `en` and the default locale is `de`) and results in an automatic redirect to the locale preferred by the browser.

## How Has This Been Tested?
Tested locally with a generic commercetools project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [x] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

