### PR TITLE
fix(core): prevent http cache module from setting headers after they had been sent

### DIFF
--- a/packages/http-cache/__tests__/renderRouteCallback.spec.ts
+++ b/packages/http-cache/__tests__/renderRouteCallback.spec.ts
@@ -6,7 +6,8 @@ import renderRouteCallback from '../nuxt/renderRouteCallback';
 const response = {
   res: {
     setHeader: jest.fn(),
-    removeHeader: jest.fn()
+    removeHeader: jest.fn(),
+    headersSent: false
   }
 };
 
@@ -16,6 +17,9 @@ const response = {
 jest.mock('../nuxt/isUrlMatchingRule', () => jest.fn(() => true));
 
 describe('renderRouteCallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('adds default cache-control header', () => {
     const options = {};
 
@@ -59,5 +63,11 @@ describe('renderRouteCallback', () => {
 
     renderRouteCallback(options)('/c/123', null, response);
     expect(response.res.removeHeader).toBeCalledWith('Cache-Control');
+  });
+
+  it('does not set headers if they had been sent already', () => {
+    const options = {};
+    renderRouteCallback(options)('/c/123', null, { res: { ...response.res, headersSent: true }});
+    expect(response.res.setHeader).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/http-cache/nuxt/renderRouteCallback.ts
+++ b/packages/http-cache/nuxt/renderRouteCallback.ts
@@ -2,6 +2,7 @@ import isUrlMatchingRule from './isUrlMatchingRule';
 import { HttpCacheModuleParams } from './types';
 
 const renderRouteCallback = ({ default: defaultHeaderValue = 'max-age=60', matchRoute = {} }: HttpCacheModuleParams) => (url, result, { res }): void => {
+  if (res.headersSent) return;
   res.setHeader('Cache-Control', defaultHeaderValue);
 
   Object.entries(matchRoute).map(([rule, headerValue]: [string, string]): void => {


### PR DESCRIPTION
This simple change prevents setting response headers after they had been sent to the client.

Such scenario can happen for example when some middleware redirects the response before it reaches the http cache module logic.
![image](https://user-images.githubusercontent.com/39009379/167842590-08bedd2e-0e71-41b3-aacc-39dc165af2da.png)

