### PR TITLE
feat: added flag allowing to change language without full page reload

### DIFF
--- a/packages/docs/changelog/6752.js
+++ b/packages/docs/changelog/6752.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'Added flag allowing to change language without full page reload',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6752',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Dawid Ziobro',
+  linkToGitHubAccount: 'https://github.com/dawid-ziobro'
+};

--- a/packages/docs/getting-started/internationalization.md
+++ b/packages/docs/getting-started/internationalization.md
@@ -224,3 +224,25 @@ export default {
   },
 };
 ```
+## Page reload on language change
+
+By default, the page is reloading while changing language.
+
+To prevent this, you can set `reloadOnLanguageChange: false`  in the `i18n` configartion object in the `nuxt.config.js`.
+
+```js
+// nuxt.config.js
+
+export default {
+  i18n: {
+    reloadOnLanguageChange: false,
+  },
+};
+```
+
+::: tip
+Even though the page will not reload, this will not make all data to be translated automatically.
+:::
+
+Static strings will be translated out of the box, but for data coming from api it will not happen.
+You need to watch for language change and refetch data with new locale.

--- a/packages/docs/getting-started/internationalization.md
+++ b/packages/docs/getting-started/internationalization.md
@@ -226,9 +226,7 @@ export default {
 ```
 ## Page reload on language change
 
-By default, the page is reloading while changing language.
-
-To prevent this, you can set `reloadOnLanguageChange: false`  in the `i18n` configartion object in the `nuxt.config.js`.
+By default, the page is reloading after changing the language. To prevent this, you can set `reloadOnLanguageChange: false`  in the `i18n` configuration object in the `nuxt.config.js`.
 
 ```js
 // nuxt.config.js
@@ -240,9 +238,4 @@ export default {
 };
 ```
 
-::: tip
-Even though the page will not reload, this will not make all data to be translated automatically.
-:::
-
-Static strings will be translated out of the box, but for data coming from api it will not happen.
-You need to watch for language change and refetch data with new locale.
+Remember that some data will not be translated without a full page reload. Nuxt will automatically translate static strings, but it won't pull new data from the API. You must watch for language changes and re-fetch data with the new locale.

--- a/packages/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/nuxt-module/plugins/i18n-cookies.js
@@ -7,6 +7,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   const acceptedLanguage = app.context.req?.headers?.['accept-language'] || navigator?.languages || '';
   const isRouteValid = !!app.context.route.name;
   const autoRedirectByLocale = i18nOptions.autoRedirectByLocale ?? true;
+  const reloadOnLanguageChange = i18nOptions.reloadOnLanguageChange ?? true;
   const cookieNames = {
     currency: i18nOptions.cookies?.currencyCookieName || VSF_CURRENCY_COOKIE,
     country: i18nOptions.cookies?.countryCookieName || VSF_COUNTRY_COOKIE,
@@ -101,7 +102,9 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
       $cookies.set(cookieNames.currency, getCurrencyByLocale(newLocale), cookieOptions);
     }
 
-    window.location.href = context.route.fullPath;
+    if (reloadOnLanguageChange) {
+      window.location.href = context.route.fullPath;
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This PR is introducing a flag that is responsible for disabling full page reload on language change. By default page reload is enabled to not to introduce breaking change.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- For example closes #123  -->
<!--- Please link to the issue here: -->
CT-300

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
<!-- if appropriate, and if you made any changes in the UI layer please provide before/after screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


#### Code standards
- [ ] My code follows the code style of this project.
<!-- VSF 2 only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

