### PR TITLE
fix: update registerIntegrations function to accommodate async change for each iteration

### DIFF
--- a/packages/docs/changelog/6779.js
+++ b/packages/docs/changelog/6779.js
@@ -1,0 +1,8 @@
+module.exports = {
+  description: 'fix: update registerIntegrations function to accommodate async change for each iteration. After changing the registerIntegration function to an async function the reduce loop did not accumulate integrations data due to a non-resolved promise. Now each iteration will be properly accumulated in the response object.',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6779',
+  isBreaking: false,
+  breakingChanges: [],
+  author: 'Bartosz Herba',
+  linkToGitHubAccount: 'https://github.com/bartoszherba'
+};

--- a/packages/middleware/src/integrations.ts
+++ b/packages/middleware/src/integrations.ts
@@ -69,9 +69,9 @@ async function getInitConfig({ apiClient, tag, integration }: LoadInitConfigProp
 }
 
 async function registerIntegrations(app: Express, integrations: IntegrationsSection): Promise<IntegrationsLoaded> {
-  return Object.entries<Integration>(integrations).reduce(async (prev, [tag, integration]) => {
+  return await Object.entries<Integration>(integrations).reduce(async (prevAsync, [tag, integration]) => {
     consola.info(`- Loading: ${tag} ${integration.location}`);
-
+    const prev = await prevAsync;
     const apiClient: ApiClientFactory = resolveDependency<ApiClientFactory>(integration.location);
     const rawExtensions: ApiClientExtension[] = createRawExtensions(apiClient, integration);
     const extensions: ApiClientExtension[] = createExtensions(rawExtensions);
@@ -97,7 +97,7 @@ async function registerIntegrations(app: Express, integrations: IntegrationsSect
         customQueries: integration.customQueries
       }
     };
-  }, {});
+  }, Promise.resolve({}));
 }
 
 export { registerIntegrations };


### PR DESCRIPTION
## Description
After changing the registerIntegration function to an async function the reduce loop did not accumulate integrations data due to a non-resolved promise. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
<!-- if appropriate, and if you made any changes in the UI layer please provide before/after screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!-- VSF 1 only -->
> I tested manually my code, and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme

#### Code standards
- [ ] My code follows the code style of this project.
<!-- VSF 2 only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

