### PR TITLE
fix: location of types for middleware package

### DIFF
--- a/packages/middleware/api-extractor.json
+++ b/packages/middleware/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "extends": "../api-extractor.base.json",
-  "mainEntryPointFilePath": "./lib/src/index.d.ts",
+  "mainEntryPointFilePath": "./lib/index.d.ts",
   "dtsRollup": {
     "untrimmedFilePath": "./lib/<unscopedPackageName>.d.ts"
   },

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
-  "types": "lib/src/index.d.ts",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "test": "jest",


### PR DESCRIPTION
[This PR](https://github.com/vuestorefront/vue-storefront/pull/6783) changed the path to types for the middleware package, causing the docs build process to fail.