### PR TITLE
feat: plugins pass Host header in server to server communication

### DIFF
--- a/packages/core/__tests__/utils/nuxt/proxyUtils.spec.ts
+++ b/packages/core/__tests__/utils/nuxt/proxyUtils.spec.ts
@@ -29,7 +29,7 @@ describe('[CORE - utils] _proxyUtils', () => {
   });
 
   it('it combines config with the current one', () => {
-    jest.spyOn(utils, 'getCookies').mockReturnValue('');
+    jest.spyOn(utils, 'getCookies').mockReturnValueOnce('');
 
     expect(utils.getIntegrationConfig(
       {
@@ -48,7 +48,7 @@ describe('[CORE - utils] _proxyUtils', () => {
   });
 
   it('it combines config with the current one and adds a cookie', () => {
-    jest.spyOn(utils, 'getCookies').mockReturnValue('xxx');
+    jest.spyOn(utils, 'getCookies').mockReturnValueOnce('xxx');
 
     expect(utils.getIntegrationConfig(
       {
@@ -62,6 +62,29 @@ describe('[CORE - utils] _proxyUtils', () => {
         baseURL: 'http://localhost.com/api',
         headers: {
           cookie: 'xxx'
+        }
+      }
+    });
+  });
+
+  it('it combines config with the current one and adds a Host header', () => {
+    expect(utils.getIntegrationConfig(
+      {
+        $config: {
+          middlewareUrl: 'http://localhost.com'
+        },
+        req: {
+          headers: {
+            host: 'mywebsite.local'
+          }
+        }
+      } as any,
+      {}
+    )).toEqual({
+      axios: {
+        baseURL: 'http://localhost.com/api',
+        headers: {
+          Host: 'mywebsite.local'
         }
       }
     });

--- a/packages/core/src/utils/nuxt/_proxyUtils.ts
+++ b/packages/core/src/utils/nuxt/_proxyUtils.ts
@@ -37,7 +37,8 @@ export const getIntegrationConfig = (context: NuxtContext, configuration: any) =
     axios: {
       baseURL: new URL(/\/api\//gi.test(baseURL) ? '' : 'api', baseURL).toString(),
       headers: {
-        ...(cookie ? { cookie } : {})
+        ...(cookie ? { cookie } : {}),
+        ...(context.req ? { Host: context.req.headers.host } : {})
       }
     }
   }, configuration);

--- a/packages/docs/changelog/6810.js
+++ b/packages/docs/changelog/6810.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'feat!: plugins pass Host header in server to server communication #6810. Previously headers other than Cookie have been lost in server to server communication. Now it\'s passed to the axios client of plugins and works as expected.',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6810',
+  isBreaking: false,
+  author: 'Filip Jędrasik',
+  linkToGitHubAccount: 'https://github.com/Fifciu'
+};


### PR DESCRIPTION
## Description
We are able to figure out what host is (domain) from middleware integrations.

## Issue
It looks like, we are losing headers other than Cookie in Nuxt server <-> Middleware server communication. In the case of, Nuxt client <-> Middleware server - everything works well. The reason could be found here: [vue-storefront/_proxyUtils.ts at main · vuestorefront/vue-storefront](https://github.com/vuestorefront/vue-storefront/blob/main/packages/core/src/utils/nuxt/_proxyUtils.ts#L40)

## Motivation and Context
It's essential for our approach to multistore.

## How Has This Been Tested?
Manually, during the development of EPCC multistore. In addition, there is a unit test that covers the feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [x] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [x] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)
