### PR TITLE
fix: not using deprecated set output

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,7 +23,7 @@ jobs:
           path: version.txt
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat version.txt)
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
       - name: Build and publish docker image
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -45,7 +45,7 @@ jobs:
           name: version
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat version.txt)
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
       - uses: chrnorm/deployment-action@releases/v1
         name: Create GitHub deployment
         id: deployment


### PR DESCRIPTION
## Description 
It fixes the usage of the deprecated --set-output command. Now, we are using a modern up-to-date approach.

## Jira

[IN-1647](https://vsf.atlassian.net/jira/software/c/projects/IN/boards/108?modal=detail&selectedIssue=IN-1647&assignee=5fcf86faa1d3f100684db878)