### PR TITLE
feat: allow overwriting i18n configuration through plugins

### DIFF
--- a/packages/docs/changelog/6850.js
+++ b/packages/docs/changelog/6850.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'feat: allow overwriting i18n configuration through plugins',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6850',
+  isBreaking: false,
+  author: 'Łukasz Śliwa',
+  linkToGitHubAccount: 'https://github.com/lsliwaradioluz'
+};

--- a/packages/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/nuxt-module/plugins/i18n-cookies.js
@@ -23,7 +23,6 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     ...i18nOptions.autoChangeCookie,
   };
 
-
   const getDefaultLocale = () => app.$config.defaultLocale;
   const getDefaultCurrency = () => app.$config.defaultCurrency;
   const getDefaultCountry = () => app.$config.defaultCountry;

--- a/packages/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/nuxt-module/plugins/i18n-cookies.js
@@ -24,8 +24,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   };
 
   const getCurrencyByLocale = (locale) =>
-    app.$config.defaultCurrency
-    || i18n.numberFormats?.[locale]?.currency?.currency
+    i18n.numberFormats?.[locale]?.currency?.currency
     || i18nOptions.currency
     || (i18nOptions.currencies.length && i18nOptions.currencies[0].name);
 
@@ -48,7 +47,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   if (isServer) {
     app.i18n.cookieValues = {
       ...(autoChangeCookie.locale && { [cookieNames.locale]: targetLocale }),
-      ...(autoChangeCookie.currency && { [cookieNames.currency]: getCurrencyByLocale(targetLocale) })
+      ...(autoChangeCookie.currency && { [cookieNames.currency]: app.$config.defaultCurrency || getCurrencyByLocale(targetLocale) })
     };
 
     if (autoRedirectByLocale && redirectPath) {
@@ -65,7 +64,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   };
   const settings = {
     locale: targetLocale,
-    currency: getCurrencyByLocale(targetLocale),
+    currency: app.$config.defaultCurrency || getCurrencyByLocale(targetLocale),
     country: app.$config.defaultCountry || i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
   };
 
@@ -100,7 +99,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     }
 
     if (autoChangeCookie.currency) {
-      $cookies.set(cookieNames.currency, getCurrencyByLocale(newLocale), cookieOptions);
+      $cookies.set(cookieNames.currency, app.$config.defaultCurrency || getCurrencyByLocale(newLocale), cookieOptions);
     }
 
     if (reloadOnLanguageChange) {

--- a/packages/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/nuxt-module/plugins/i18n-cookies.js
@@ -24,13 +24,14 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   };
 
   const getCurrencyByLocale = (locale) =>
-    i18n.numberFormats?.[locale]?.currency?.currency
+    app.$config.defaultCurrency
+    || i18n.numberFormats?.[locale]?.currency?.currency
     || i18nOptions.currency
-    || i18nOptions.currencies && (i18nOptions.currencies.length && i18nOptions.currencies[0].name);
+    || (i18nOptions.currencies.length && i18nOptions.currencies[0].name);
 
   const utils = i18nRedirectsUtil({
     path: app.context.route.path,
-    defaultLocale: i18nOptions.defaultLocale,
+    defaultLocale: app.$config.defaultLocale ?? i18nOptions.defaultLocale,
     availableLocales: i18nOptions.locales.map((item) => item.code),
     acceptedLanguages: isServer ? acceptedLanguage.split(',').map((item) => item.split(';')[0]) : acceptedLanguage,
     cookieLocale,
@@ -62,11 +63,11 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)), // Year from now
     ...i18nOptions.cookieOptions
   };
-  const settings = {};
-
-  if (autoChangeCookie.locale) settings.locale = targetLocale;
-  if (autoChangeCookie.currency) settings.currency = getCurrencyByLocale(targetLocale);
-  if (autoChangeCookie.country) settings.country = i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
+  const settings = {
+    locale: targetLocale,
+    currency: getCurrencyByLocale(targetLocale),
+    country: app.$config.defaultCountry || i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
+  };
 
   const missingFields = Object
     .entries(settings)

--- a/packages/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/nuxt-module/plugins/i18n-cookies.js
@@ -26,7 +26,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   const getCurrencyByLocale = (locale) =>
     i18n.numberFormats?.[locale]?.currency?.currency
     || i18nOptions.currency
-    || (i18nOptions.currencies.length && i18nOptions.currencies[0].name);
+    || i18nOptions.currencies && (i18nOptions.currencies.length && i18nOptions.currencies[0].name);
 
   const utils = i18nRedirectsUtil({
     path: app.context.route.path,
@@ -62,11 +62,11 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)), // Year from now
     ...i18nOptions.cookieOptions
   };
-  const settings = {
-    locale: targetLocale,
-    currency: getCurrencyByLocale(targetLocale),
-    country: i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
-  };
+  const settings = {};
+
+  if (autoChangeCookie.locale) settings.locale = targetLocale;
+  if (autoChangeCookie.currency) settings.currency = getCurrencyByLocale(targetLocale);
+  if (autoChangeCookie.country) settings.country = i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
 
   const missingFields = Object
     .entries(settings)

--- a/packages/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/nuxt-module/plugins/i18n-cookies.js
@@ -23,14 +23,20 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     ...i18nOptions.autoChangeCookie,
   };
 
+
+  const getDefaultLocale = () => app.$config.defaultLocale;
+  const getDefaultCurrency = () => app.$config.defaultCurrency;
+  const getDefaultCountry = () => app.$config.defaultCountry;
+  
   const getCurrencyByLocale = (locale) =>
     i18n.numberFormats?.[locale]?.currency?.currency
     || i18nOptions.currency
     || (i18nOptions.currencies.length && i18nOptions.currencies[0].name);
 
+
   const utils = i18nRedirectsUtil({
     path: app.context.route.path,
-    defaultLocale: app.$config.defaultLocale ?? i18nOptions.defaultLocale,
+    defaultLocale: getDefaultLocale() ?? i18nOptions.defaultLocale,
     availableLocales: i18nOptions.locales.map((item) => item.code),
     acceptedLanguages: isServer ? acceptedLanguage.split(',').map((item) => item.split(';')[0]) : acceptedLanguage,
     cookieLocale,
@@ -47,7 +53,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   if (isServer) {
     app.i18n.cookieValues = {
       ...(autoChangeCookie.locale && { [cookieNames.locale]: targetLocale }),
-      ...(autoChangeCookie.currency && { [cookieNames.currency]: app.$config.defaultCurrency || getCurrencyByLocale(targetLocale) })
+      ...(autoChangeCookie.currency && { [cookieNames.currency]: getDefaultCurrency() || getCurrencyByLocale(targetLocale) })
     };
 
     if (autoRedirectByLocale && redirectPath) {
@@ -64,8 +70,8 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   };
   const settings = {
     locale: targetLocale,
-    currency: app.$config.defaultCurrency || getCurrencyByLocale(targetLocale),
-    country: app.$config.defaultCountry || i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
+    currency: getDefaultCurrency() || getCurrencyByLocale(targetLocale),
+    country: getDefaultCountry() || i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
   };
 
   const missingFields = Object
@@ -99,7 +105,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     }
 
     if (autoChangeCookie.currency) {
-      $cookies.set(cookieNames.currency, app.$config.defaultCurrency || getCurrencyByLocale(newLocale), cookieOptions);
+      $cookies.set(cookieNames.currency, getDefaultCurrency() || getCurrencyByLocale(newLocale), cookieOptions);
     }
 
     if (reloadOnLanguageChange) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
As a developer, I want to be able to change the default currency and locale at runtime. An example might be a multistore setup where I might have a plugin loading the store configuration including default language and currency for the store (which is a pretty common scenario).

Unfortunately, the current implementation of the i18n-cookies plugin only relies on properties provided in `nuxt.config.js`. Therefore, influencing the outcome of this plugin at runtime is rather impossible - not good in a multistore setup where we have a single Vue Storefront application displaying several separate stores with different locale/currency settings.

This PR creates a gateway for Nuxt plugins to add `defaultLocale`, `defaultCurrency` and `defaultCountry` to the `context` object so that the `i18n-cookies` plugin picks these values up and does its job the usual way. An example of a flow supported by this PR could be:

1. Plugin A loads store configuration from Commerce API. The configuration contains default `language` and `currency` for the store. The plugin writes these values to the application `context` object.
2. Plugin b (i18n-cookies) reads these values from the `context`. If it does not find them, it falls back to the configuration defined in `nuxt.config.js`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- For example closes #123  -->
<!--- Please link to the issue here: -->
[IN-1576](https://vsf.atlassian.net/browse/IN-1576)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.