### PR TITLE
chore(release): v2.7.3

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
           path: version.txt
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat version.txt)
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
       - name: Build and publish docker image
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -46,7 +46,7 @@ jobs:
           name: version
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat version.txt)
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
       - uses: chrnorm/deployment-action@releases/v1
         name: Create GitHub deployment
         id: deployment

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/cache",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "license": "MIT",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -12,7 +12,7 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@vue-storefront/core": "~2.7.2"
+    "@vue-storefront/core": "~2.7.3"
   },
   "peerDependencies": {
     "@nuxtjs/composition-api": "^0.29.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/core",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -13,7 +13,7 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "axios": "0.21.2",
+    "axios": "0.22.0",
     "express": "^4.17.1",
     "lodash-es": "^4.17.15",
     "vue": "^2.6.11"

--- a/packages/core/src/utils/nuxt/index.ts
+++ b/packages/core/src/utils/nuxt/index.ts
@@ -26,11 +26,6 @@ export const integrationPlugin = (pluginFn: NuxtPlugin) => (nuxtCtx: NuxtContext
     const injectInContext = createAddIntegrationToCtx({ tag, nuxtCtx, inject });
     const config = getIntegrationConfig(nuxtCtx, configuration);
 
-    const { middlewareUrl, ssrMiddlewareUrl } = nuxtCtx.$config;
-    if (middlewareUrl) {
-      config.axios.baseURL = process.server ? middlewareUrl || ssrMiddlewareUrl : middlewareUrl;
-    }
-
     const client = axios.create(config.axios);
     const api = createProxiedApi({ givenApi: configuration.api || {}, client, tag });
 

--- a/packages/docs/changelog/6848.js
+++ b/packages/docs/changelog/6848.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'build(deps): bump axios from 0.21.2 to 0.22.0',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6848',
+  isBreaking: false,
+  author: 'Jeff Paltera',
+  linkToGitHubAccount: 'https://github.com/jeffpdotone'
+};

--- a/packages/docs/changelog/6850.js
+++ b/packages/docs/changelog/6850.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'feat: allow overwriting i18n configuration through plugins',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6850',
+  isBreaking: false,
+  author: 'Łukasz Śliwa',
+  linkToGitHubAccount: 'https://github.com/lsliwaradioluz'
+};

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/middleware",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -15,7 +15,7 @@
   "author": "Vue Storefront",
   "license": "MIT",
   "dependencies": {
-    "@vue-storefront/core": "~2.7.2",
+    "@vue-storefront/core": "~2.7.3",
     "consola": "2.15.3",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/packages/nuxt-module/plugins/i18n-cookies.js
+++ b/packages/nuxt-module/plugins/i18n-cookies.js
@@ -23,14 +23,19 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     ...i18nOptions.autoChangeCookie,
   };
 
+  const getDefaultLocale = () => app.$config.defaultLocale;
+  const getDefaultCurrency = () => app.$config.defaultCurrency;
+  const getDefaultCountry = () => app.$config.defaultCountry;
+  
   const getCurrencyByLocale = (locale) =>
     i18n.numberFormats?.[locale]?.currency?.currency
     || i18nOptions.currency
     || (i18nOptions.currencies.length && i18nOptions.currencies[0].name);
 
+
   const utils = i18nRedirectsUtil({
     path: app.context.route.path,
-    defaultLocale: i18nOptions.defaultLocale,
+    defaultLocale: getDefaultLocale() ?? i18nOptions.defaultLocale,
     availableLocales: i18nOptions.locales.map((item) => item.code),
     acceptedLanguages: isServer ? acceptedLanguage.split(',').map((item) => item.split(';')[0]) : acceptedLanguage,
     cookieLocale,
@@ -47,7 +52,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   if (isServer) {
     app.i18n.cookieValues = {
       ...(autoChangeCookie.locale && { [cookieNames.locale]: targetLocale }),
-      ...(autoChangeCookie.currency && { [cookieNames.currency]: getCurrencyByLocale(targetLocale) })
+      ...(autoChangeCookie.currency && { [cookieNames.currency]: getDefaultCurrency() || getCurrencyByLocale(targetLocale) })
     };
 
     if (autoRedirectByLocale && redirectPath) {
@@ -64,8 +69,8 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
   };
   const settings = {
     locale: targetLocale,
-    currency: getCurrencyByLocale(targetLocale),
-    country: i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
+    currency: getDefaultCurrency() || getCurrencyByLocale(targetLocale),
+    country: getDefaultCountry() || i18nOptions.country || (i18nOptions.countries.length && i18nOptions.countries[0].name)
   };
 
   const missingFields = Object
@@ -99,7 +104,7 @@ const i18nCookiesPlugin = ({ $cookies, i18n, app, redirect }) => {
     }
 
     if (autoChangeCookie.currency) {
-      $cookies.set(cookieNames.currency, getCurrencyByLocale(newLocale), cookieOptions);
+      $cookies.set(cookieNames.currency, getDefaultCurrency() || getCurrencyByLocale(newLocale), cookieOptions);
     }
 
     if (reloadOnLanguageChange) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4758,12 +4758,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.22.0.tgz#bf702c41fb50fbca4539589d839a077117b79b25"
+  integrity sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.4"
 
 babel-jest@^27.5.1:
   version "27.5.1"
@@ -8493,10 +8493,15 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+follow-redirects@^1.0.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
+follow-redirects@^1.14.4:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
In this release we:
- made new url constructor in core package able to work with api
- allowed overwriting i18n configuration through plugins
- updated `axios` from v0.21.2 to v0.22.0