### PR TITLE
fix:(in-1921): added x-forwarded-host to condition

### DIFF
--- a/packages/core/__tests__/utils/nuxt/proxyUtils.spec.ts
+++ b/packages/core/__tests__/utils/nuxt/proxyUtils.spec.ts
@@ -89,4 +89,29 @@ describe('[CORE - utils] _proxyUtils', () => {
       }
     });
   });
+
+  it('it combines config with the current one and adds a Host header', () => {
+    expect(utils.getIntegrationConfig(
+      {
+        $config: {
+          middlewareUrl: 'http://localhost.com'
+        },
+        req: {
+          headers: {
+            'x-forwarded-host': 'mywebsite.local',
+            cookie: 'xxx'
+          }
+        }
+      } as any,
+      {}
+    )).toEqual({
+      axios: {
+        baseURL: 'http://localhost.com/api',
+        headers: {
+          Host: 'mywebsite.local',
+          cookie: 'xxx'
+        }
+      }
+    });
+  });
 });

--- a/packages/core/src/utils/nuxt/_proxyUtils.ts
+++ b/packages/core/src/utils/nuxt/_proxyUtils.ts
@@ -33,12 +33,14 @@ export const getIntegrationConfig = (context: NuxtContext, configuration: any) =
     Logger.info('Applied middlewareUrl as ', context.$config.middlewareUrl);
   }
 
+  const resolvedHost = context?.req?.headers?.['x-forwarded-host'] || context?.req?.headers?.host;
+
   return merge({
     axios: {
       baseURL: new URL(/\/api\//gi.test(baseURL) ? '' : 'api', baseURL).toString(),
       headers: {
         ...(cookie ? { cookie } : {}),
-        ...(context.req ? { Host: context.req.headers.host } : {})
+        ...(resolvedHost ? { Host: resolvedHost } : {})
       }
     }
   }, configuration);


### PR DESCRIPTION
Fix to add in the condition and see if there's an available x-forwarded-host headers

## Description
The changes will take in condition and see whether the x-forwarded-host is available or not fallback to another host property that can determine the domain/host it's coming from.

## Related Issue
Integrations we're not able to work correctly because of the missing host which is required by some of the APIs.

## Motivation and Context
This will prevent the integrations from not working because of the missing host.

## How Has This Been Tested?
Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [x] I have written test cases for my code
- [ ] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!-- VSF 1 only -->
> I tested manually my code, and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme

#### Code standards
- [ ] My code follows the code style of this project.
<!-- VSF 2 only -->
- [x] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

