### PR TITLE
fix: use any type as configuration in ApiClientExtension

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -831,7 +831,7 @@ export type ApiClientMethod = (...args: any) => Promise<any>
 export interface ApiClientExtension {
   name: string;
   extendApiMethods?: Record<string, ApiClientMethod>;
-  extendApp?: (params: { app: Express, configuration: unknown }) => void;
+  extendApp?: (params: { app: Express, configuration: any }) => void;
   hooks?: (req: Request, res: Response) => ApiClientExtensionHooks;
 }
 

--- a/packages/docs/changelog/6862.js
+++ b/packages/docs/changelog/6862.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'fix: use any type as configuration in ApiClientExtension',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6862',
+  isBreaking: false,
+  author: 'Wojciech Sikora',
+  linkToGitHubAccount: 'https://github.com/WojtekTheWebDev'
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Release v2.7.3 introduced an unexpected change in types which changes `any` to `unknown`.
This could breaks some apps, needs to be reversed.
