### PR TITLE
chore: release v2.7.4

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/cache",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "license": "MIT",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -12,7 +12,7 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@vue-storefront/core": "~2.7.3"
+    "@vue-storefront/core": "~2.7.4"
   },
   "peerDependencies": {
     "@nuxtjs/composition-api": "^0.29.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/core",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/docs/changelog/6862.js
+++ b/packages/docs/changelog/6862.js
@@ -1,7 +1,0 @@
-module.exports = {
-  description: 'fix: use any type as configuration in ApiClientExtension',
-  link: 'https://github.com/vuestorefront/vue-storefront/pull/6862',
-  isBreaking: false,
-  author: 'Wojciech Sikora',
-  linkToGitHubAccount: 'https://github.com/WojtekTheWebDev'
-};

--- a/packages/docs/reference/changelog.md
+++ b/packages/docs/reference/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.4
+
+- fix: use any type as configuration in ApiClientExtension ([6862](https://github.com/vuestorefront/vue-storefront/pull/6862)) - [Wojciech Sikora](https://github.com/WojtekTheWebDev)
+
 ## 2.7.3
 
 - feat: make new url constructor in core package able to work with api ([6846](https://github.com/vuestorefront/vue-storefront/pull/6846)) - [Bartosz Herba](https://github.com/bartoszherba)

--- a/packages/health-check/package.json
+++ b/packages/health-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/health-check",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "",
   "main": "lib/module.js",
   "scripts": {

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/middleware",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -15,7 +15,7 @@
   "author": "Vue Storefront",
   "license": "MIT",
   "dependencies": {
-    "@vue-storefront/core": "~2.7.3",
+    "@vue-storefront/core": "~2.7.4",
     "consola": "2.15.3",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/nuxt",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "types": "lib/src/index.d.ts",

--- a/packages/nuxt-theme-module/package.json
+++ b/packages/nuxt-theme-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/nuxt-theme",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "",
   "main": "lib/module.js",
   "scripts": {


### PR DESCRIPTION
# Changelog

## 2.7.4

- fix: use any type as configuration in ApiClientExtension ([6862](https://github.com/vuestorefront/vue-storefront/pull/6862)) - [Wojciech Sikora](https://github.com/WojtekTheWebDev)