### PR TITLE
chore: bump http-cache version

### DIFF
--- a/packages/http-cache/package.json
+++ b/packages/http-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/http-cache",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "license": "MIT",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Bump version missing in 2.7.4