### PR TITLE
fix: passing x-forwarded-host in axios request

### DIFF
--- a/packages/core/__tests__/utils/nuxt/proxyUtils.spec.ts
+++ b/packages/core/__tests__/utils/nuxt/proxyUtils.spec.ts
@@ -30,7 +30,7 @@ describe('[CORE - utils] _proxyUtils', () => {
     expect(utils.getCookies({ req: { headers: { cookie: { someCookie: 1 } } } } as any)).toEqual({ someCookie: 1 });
   });
 
-  it('it combines config with the current one', () => {
+  it('combines config with the current one', () => {
     jest.spyOn(utils, 'getCookies').mockReturnValue('');
 
     const integrationConfig = utils.getIntegrationConfig(
@@ -51,7 +51,7 @@ describe('[CORE - utils] _proxyUtils', () => {
     });
   });
 
-  it('it combines config with the current one and adds a cookie', () => {
+  it('combines config with the current one and adds a cookie', () => {
     jest.spyOn(utils, 'getCookies').mockReturnValue('xxx');
 
     const integrationConfig = utils.getIntegrationConfig(
@@ -73,6 +73,56 @@ describe('[CORE - utils] _proxyUtils', () => {
     });
   });
 
+  it('adds a X-Forwarded-Host header', () => {
+    const integrationConfig = utils.getIntegrationConfig(
+      {
+        $config: {
+          middlewareUrl: 'http://localhost.com'
+        },
+        req: {
+          headers: {
+            'x-forwarded-host': 'myforward.vsf'
+          }
+        }
+      } as any,
+      {}
+    );
+
+    expect(integrationConfig).toEqual({
+      axios: {
+        baseURL: expect.any(String),
+        headers: expect.objectContaining({
+          'X-Forwarded-Host': 'myforward.vsf'
+        })
+      }
+    });
+  });
+
+  it('adds a Host header', () => {
+    const integrationConfig = utils.getIntegrationConfig(
+      {
+        $config: {
+          middlewareUrl: 'http://localhost.com'
+        },
+        req: {
+          headers: {
+            host: 'mywebsite.local'
+          }
+        }
+      } as any,
+      {}
+    );
+
+    expect(integrationConfig).toEqual({
+      axios: {
+        baseURL: expect.any(String),
+        headers: expect.objectContaining({
+          Host: 'mywebsite.local'
+        })
+      }
+    });
+  });
+
   /**
    * baseURL configuration cases matrix
    */
@@ -85,7 +135,7 @@ describe('[CORE - utils] _proxyUtils', () => {
   ];
 
   const testMsg = '[baseUrl must be configured properly for] server: $server, middlewareUrl: $middlewareUrl, ssrMiddlewareUrl: $ssrMiddlewareUrl, expected: $expected';
-  test.each(urlSetupCases)(testMsg, ({ server, middlewareUrl, ssrMiddlewareUrl, expected }) => {
+  it.each(urlSetupCases)(testMsg, ({ server, middlewareUrl, ssrMiddlewareUrl, expected }) => {
     process.server = server;
 
     const integrationConfig = utils.getIntegrationConfig(
@@ -113,4 +163,5 @@ describe('[CORE - utils] _proxyUtils', () => {
       utils.getIntegrationConfig({ $config: { middlewareUrl: undefined } } as any, {});
     }).toThrow('`middlewareUrl` is required. Provide the `middlewareUrl` in your integration\'s configuration.');
   });
+
 });

--- a/packages/core/src/utils/nuxt/_proxyUtils.ts
+++ b/packages/core/src/utils/nuxt/_proxyUtils.ts
@@ -43,13 +43,16 @@ export const getIntegrationConfig = (context: NuxtContext, configuration: any) =
     baseURL = `/${baseURL}`;
   }
 
+  const headers = {};
+  cookie && Object.assign(headers, { cookie });
+  const reqHeaders = context.req?.headers;
+  reqHeaders?.['x-forwarded-host'] && Object.assign(headers, { 'X-Forwarded-Host': reqHeaders['x-forwarded-host'] });
+  reqHeaders?.host && Object.assign(headers, { Host: reqHeaders.host });
+
   return merge({
     axios: {
       baseURL,
-      headers: {
-        ...(cookie ? { cookie } : {}),
-        ...(context.req ? { Host: context.req.headers.host } : {})
-      }
+      headers
     }
   }, configuration);
 };

--- a/packages/docs/changelog/6869.js
+++ b/packages/docs/changelog/6869.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'feat!: plugins pass X-Forwarded-Host header with fallback to the Host header in server to server communication #6869.',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6869',
+  isBreaking: false,
+  author: 'Filip Jędrasik',
+  linkToGitHubAccount: 'https://github.com/Fifciu'
+};


### PR DESCRIPTION
## Description

Around a month ago, I added functionality that passes the original value of the Host header when sending a request from the Nuxt server to the middleware. This PR adds also an X-Forwarded-Host header as it's essential to use it if the infrastructure has a reverse proxy.

It's the following one with resolved conflicts: https://github.com/vuestorefront/vue-storefront/pull/6818