### PR TITLE
chore: passing x-forwarded-host with fallback to host as host in axios

### DIFF
--- a/packages/core/src/utils/nuxt/_proxyUtils.ts
+++ b/packages/core/src/utils/nuxt/_proxyUtils.ts
@@ -48,7 +48,7 @@ export const getIntegrationConfig = (context: NuxtContext, configuration: any) =
       baseURL,
       headers: {
         ...(cookie ? { cookie } : {}),
-        ...(context.req ? { Host: context.req.headers.host } : {})
+        ...(context.req ? { Host: context.req.headers['x-forwarded-host'] || context.req.headers.host } : {})
       }
     }
   }, configuration);

--- a/packages/docs/changelog/6871.js
+++ b/packages/docs/changelog/6871.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'feat: plugins pass X-Forwarded-Host header with fallback to the Host header as a Host in axios server to server communication #6871.',
+  link: 'https://github.com/vuestorefront/vue-storefront/pull/6871',
+  isBreaking: false,
+  author: 'Filip Jędrasik',
+  linkToGitHubAccount: 'https://github.com/Fifciu'
+};


### PR DESCRIPTION
chore: passing x-forwarded-host with fallback to host as host in axios