### PR TITLE
fix: change npm install and npm run dev to yarn according to docs

### DIFF
--- a/packages/cli/locales/en-US/translation.json
+++ b/packages/cli/locales/en-US/translation.json
@@ -12,10 +12,10 @@
         "skipping": "Can't generate the store. Skipping…",
         "success": "Sucessfully generated your store at \"./{{projectName}}\"!",
         "install": "To finish the installation, run the following commands:",
-        "install_commands": ["cd {{ projectName }}", "npm install"],
+        "install_commands": ["cd {{ projectName }}", "yarn"],
         "configure": "Then, go to the {{ documentationURL }} to learn how to configure the project.",
         "start": "Once finished, you can start the project using this command:",
-        "start_command": "npm run dev"
+        "start_command": "yarn dev"
       }
     },
     "generate_template": {

--- a/packages/cli/locales/pt-BR/translation.json
+++ b/packages/cli/locales/pt-BR/translation.json
@@ -12,10 +12,10 @@
         "skipping": "Não é possível gerar a loja. Pulando…",
         "success": "Loja gerada com sucesso em \"./{{projectName}}\"!",
         "install": "Para finalizar a instalação, execute os comandos abaixo:",
-        "install_commands": ["cd {{ projectName }}", "npm install"],
+        "install_commands": ["cd {{ projectName }}", "yarn"],
         "configure": "Depois, acesse {{ documentationURL }} para aprender a configurar o projeto.",
         "start": "Ao finalizar, você pode inicializar o projeto com o comando:",
-        "start_command": "npm run dev"
+        "start_command": "yarn dev"
       }
     },
     "generate_template": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Previously after installation with the CLI, users were receiving the following message

```
To finish the installation, run the following commands:

cd vsf-magento-playground
npm install

Then, go to the https://docs.vuestorefront.io/magento/ to learn how to configure the project.
Once finished, you can start the project using this command:

npm run dev
```




## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- For example closes #123  -->
<!--- Please link to the issue here: -->

Closing #6879 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Better DX

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built-in test suites:

**Test Suites**: 16 passed, 16 total
**Tests**:       29 passed, 29 total

```
sergiikirianov@Sergiis-MBP-2 cli % ./bin/run generate store
? What's your project name? test
? Choose an integration template: Magento 2
████████████████████████████████████████ || 100%
Sucessfully generated your store at "./test"!
To finish the installation, run the following commands:

cd test
yarn

Then, go to the https://docs.vuestorefront.io/magento/ to learn how to configure the project.
Once finished, you can start the project using this command:

yarn dev
```


## Screenshots:
<!-- if appropriate, and if you made any changes in the UI layer please provide before/after screenshots -->
Before:

<img width="577" alt="Screenshot 2023-01-19 at 13 11 21" src="https://user-images.githubusercontent.com/74229951/213451409-febe6e27-aa9b-4d03-9389-48627b7f6b97.png">


After: 
<img width="577" alt="Screenshot 2023-01-19 at 13 10 38" src="https://user-images.githubusercontent.com/74229951/213451260-485964fc-1061-4df0-a1d9-031864a7ee13.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

#### Changelog
- [ ] I have updated the Changelog ([V1](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md)) [v2](https://docs-next.vuestorefront.io/contributing/creating-changelog.html) and mentioned all breaking changes in the public API.
- [ ] I have documented all new public APIs and made changes to existing docs mentioning the parts I've changed so they're up to date.

#### Tests
- [ ] I have written test cases for my code
- [x] I have tested my Pull Request on production build and (to my knowledge) it works without any issues
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!-- VSF 1 only -->
> I tested manually my code, and it works well with both:
- [ ] Default Theme
- [ ] Capybara Theme

#### Code standards
- [x] My code follows the code style of this project.
<!-- VSF 2 only -->
- [ ] I have followed [naming conventions](https://github.com/kettanaito/naming-cheatsheet)

#### Docs
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

