### PR TITLE
test: caching extension for GET endpoints

### DIFF
--- a/packages/cli/__tests__/domains/async/wait.spec.ts
+++ b/packages/cli/__tests__/domains/async/wait.spec.ts
@@ -10,6 +10,6 @@ describe("wait | unit tests", () => {
     const after = performance.now();
 
     // Math.round because of the inaccuracy of the JavaScript floats.
-    expect(Math.round(after - before)).toBeGreaterThanOrEqual(100);
+    expect(Math.ceil(after - before)).toBeGreaterThanOrEqual(100);
   });
 });

--- a/packages/middleware/__tests__/integration/bootstrap/api/index.ts
+++ b/packages/middleware/__tests__/integration/bootstrap/api/index.ts
@@ -1,4 +1,5 @@
 export { success } from "./success";
+export { setCookieHeader } from "./setCookieHeader";
 export { error } from "./error";
 export { throwAxiosError } from "./throwAxiosError";
 export { throwError } from "./throwError";

--- a/packages/middleware/__tests__/integration/bootstrap/api/setCookieHeader/index.ts
+++ b/packages/middleware/__tests__/integration/bootstrap/api/setCookieHeader/index.ts
@@ -1,0 +1,8 @@
+export const setCookieHeader = (context) => {
+  context.res.setHeader('set-cookie', 'somecookie=12')
+  return Promise.resolve({
+    status: 200,
+    message: "ok",
+    error: false,
+  });
+};

--- a/packages/middleware/__tests__/integration/bootstrap/api/setCookieHeader/index.ts
+++ b/packages/middleware/__tests__/integration/bootstrap/api/setCookieHeader/index.ts
@@ -1,5 +1,5 @@
 export const setCookieHeader = (context) => {
-  context.res.setHeader('set-cookie', 'somecookie=12')
+  context.res.setHeader("set-cookie", "somecookie=12");
   return Promise.resolve({
     status: 200,
     message: "ok",

--- a/packages/middleware/__tests__/integration/cachingExtension.spec.ts
+++ b/packages/middleware/__tests__/integration/cachingExtension.spec.ts
@@ -91,7 +91,7 @@ describe('[Integration] Caching extension', () => {
     });
   });
 
-  it('doesn\'t add headers for not GET method', async () => {
+  it('doesn\'t add Cache-Control header for not GET method', async () => {
     const { status, body, headers } = await request(app).post('/test_integration/success');
 
     expect(status).toEqual(200);
@@ -99,7 +99,7 @@ describe('[Integration] Caching extension', () => {
     expect(headers['cache-control']).toBeUndefined();
   });
 
-  it('doesn\'t add headers if there is Set-Cookie response header', async () => {
+  it('doesn\'t add Cache-Control header if there is Set-Cookie response header', async () => {
     const { status, body, headers } = await request(app).get('/test_integration/setCookieHeader');
 
     expect(status).toEqual(200);
@@ -107,7 +107,7 @@ describe('[Integration] Caching extension', () => {
     expect(headers['cache-control']).toBeUndefined();
   });
 
-  it('adds headers if conditions are fulfilled', async () => {
+  it('adds Cache-Control header if request variables were passed via params, so there are not dependencies on cookies', async () => {
     const { status, body, headers } = await request.agent(app).get('/test_integration/success')
     .query({
       country: 'PL',
@@ -122,7 +122,7 @@ describe('[Integration] Caching extension', () => {
     expect(headers['cache-control']).toEqual("public, max-age=3600");
   });
 
-  it('doesn\'t add header if conditions are not fulfilled', async () => {
+  it('doesn\'t add Cache-Control header if request variables weren\'t passed via params, so there are dependencies on cookies', async () => {
     const { status, body, headers } = await request(app).get('/test_integration/success');
 
     expect(status).toEqual(200);

--- a/packages/middleware/__tests__/integration/cachingExtension.spec.ts
+++ b/packages/middleware/__tests__/integration/cachingExtension.spec.ts
@@ -1,0 +1,133 @@
+import { Express } from 'express';
+import request from 'supertest';
+import { createServer } from '../../src/index';
+import * as api from './bootstrap/api'
+
+const Logger = {
+  info: jest.fn()
+}
+
+const cachingExtension = {
+  name: "caching-extension",
+  hooks (req, res) {
+    return {
+      afterCall ({ response }) {
+        if (req.method !== "GET") {
+          Logger.info(
+            "[CACHING] It's not a GET request, skipping caching"
+          );
+          return response;
+        }
+
+        if (res.getHeader("set-cookie")) {
+          Logger.info(
+            "[CACHING] Response containing Set-Cookie header, skipping caching"
+          );
+          return response;
+        }
+
+        const apiMethod = req.params.functionName;
+        const params = req.query;
+        if (apiMethod === "success") {
+          if (
+            params.country &&
+            params.currency &&
+            params.locale &&
+            "channel" in params &&
+            "customerGroupId" in params
+          ) {
+            Logger.info(
+              "[CACHING] It's a success request, caching requirements fulfilled!"
+            );
+            res.set("Cache-Control", "public, max-age=3600");
+          } else {
+            Logger.info(
+              "[CACHING] It's a success request, caching requirements not fulfilled!"
+            );
+          }
+        }
+
+        return response;
+      }
+    }
+  }
+}
+
+/**
+ * The following test suite is responsible for making sure
+ * the caching extension's boilerplate in our documentation is working correctly
+ * and no one will break it accidently during working on the middleware.
+ * 
+ * Aforementioned caching extension is responsible for setting Cache-Control response header
+ * for cookie-independent requests to the GET endpoints in our integrations
+ */
+describe('[Integration] Caching extension', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
+
+  beforeAll(async () => {
+    type IntegrationContexts = {
+      test_integration: {
+        api: typeof api,
+        config: unknown,
+        client: unknown
+      }
+    }
+    app = await createServer<IntegrationContexts>({
+      integrations: {
+        test_integration: {
+          configuration: {},
+          location: './__tests__/integration/bootstrap/server',
+          extensions() {
+            return [
+              cachingExtension as any
+            ]
+          }
+        },
+      },
+    });
+  });
+
+  it('doesn\'t add headers for not GET method', async () => {
+    const { status, body, headers } = await request(app).post('/test_integration/success');
+
+    expect(status).toEqual(200);
+    expect(body.message).toEqual('ok');
+    expect(headers['cache-control']).toBeUndefined();
+  });
+
+  it('doesn\'t add headers if there is Set-Cookie response header', async () => {
+    const { status, body, headers } = await request(app).get('/test_integration/setCookieHeader');
+
+    expect(status).toEqual(200);
+    expect(body.message).toEqual('ok');
+    expect(headers['cache-control']).toBeUndefined();
+  });
+
+  it('adds headers if conditions are fulfilled', async () => {
+    const { status, body, headers } = await request.agent(app).get('/test_integration/success')
+    .query({
+      country: 'PL',
+      currency: 'PLN',
+      locale: 'pl',
+      channel: null,
+      customerGroupId: null,
+    })
+
+    expect(status).toEqual(200);
+    expect(body.message).toEqual('ok');
+    expect(headers['cache-control']).toEqual("public, max-age=3600");
+  });
+
+  it('doesn\'t add header if conditions are not fulfilled', async () => {
+    const { status, body, headers } = await request(app).get('/test_integration/success');
+
+    expect(status).toEqual(200);
+    expect(body.message).toEqual('ok');
+    expect(headers['Cache-Control']).toBeUndefined();
+  });
+
+});


### PR DESCRIPTION
### 🔗 Linked issue

[IN-3706](https://vsf.atlassian.net/browse/IN-3706)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The provided test suite is responsible for making sure the caching extension's boilerplate in our documentation is working correctly and no one will break it accidentally during working on the middleware. The aforementioned caching extension is responsible for setting Cache-Control response header for cookie-independent requests to the GET endpoints in our integrations.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


[IN-3706]: https://vsf.atlassian.net/browse/IN-3706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ