### PR TITLE
docs: updated command to vsf-enterprise packages

### DIFF
--- a/docs/content/enterprise/index.md
+++ b/docs/content/enterprise/index.md
@@ -30,5 +30,5 @@ To use them, create the `.npmrc` file with the following content at the root of 
 Then run the following command and enter your Vue Storefront Enterprise account credentials:
 
 ```bash
-npm adduser --registry https://registrynpm.storefrontcloud.io
+npm login --registry https://registrynpm.storefrontcloud.io
 ```


### PR DESCRIPTION
replacing 'npm adduser' with 'npm login'

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)

### 📚 Description
This command here
`npm adduser --registry https://registrynpm.storefrontcloud.io/`
is no longer supported, we must use instead
`npm login --registry https://registrynpm.storefrontcloud.io/`

### 📝 Checklist

- [x] I have updated the documentation accordingly.
