### PR TITLE
docs: fix sdk links

### DIFF
--- a/docs/content/4.sdk/1.index.md
+++ b/docs/content/4.sdk/1.index.md
@@ -8,7 +8,7 @@ The Vue Storefront SDK simplifies the development process by providing pre-built
 
 By utilizing the Vue Storefront SDK, you can establish a type-safe contract between your storefront and various APIs with the help of the Server Middleware acting as a proxy.
 
-:card{to="$base/getting-started" title="Get Started" description="Learn how to initialize the SDK in your storefronts" icon="ic:baseline-rocket"}
+:card{to="/sdk/getting-started" title="Get Started" description="Learn how to initialize the SDK in your storefronts" icon="ic:baseline-rocket"}
 
 
 ## Key Features

--- a/docs/content/4.sdk/2.getting-started/1.index.md
+++ b/docs/content/4.sdk/2.getting-started/1.index.md
@@ -159,7 +159,7 @@ Experiment with combining the modules that best fit your application's requireme
 
 ::grid{:columns="2"}
 #section-1
-:card{to="$base/advanced/extending-module" title="Extending the SDK" description="Learn how to customize, override, or extend any default functionality in the SDK" icon="ri:terminal-box-fill"}
+:card{to="/sdk/advanced/extending-module" title="Extending the SDK" description="Learn how to customize, override, or extend any default functionality in the SDK" icon="ri:terminal-box-fill"}
 #section-2
 :card{to="/middleware" title="Middleware Docs" description="Understand more about Vue Storefront Middleware" icon="fa6-solid:layer-group"}
 #section-3


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaces `$base/` with `/sdk/` for links on the SDK page. This change is a leftover change from when the SDK docs were migrated from a separate repo into the core docs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
