### PR TITLE
fix(UST-1087): move `@vue-storefront/sdk` to dependencies for nuxt and next

### DIFF
--- a/docs/content/4.sdk/2.getting-started/1.index.md
+++ b/docs/content/4.sdk/2.getting-started/1.index.md
@@ -10,20 +10,7 @@ There are various ways to configure the SDK, depending on your chosen framework.
 
 ## Installation
 
-Next.js SDK module is based on the Vue Storefront SDK Core. In order to use the Next.js SDK module, first you need to install the SDK Core.
-
-```bash [SDK Core]
-# Using yarn
-yarn add @vue-storefront/sdk
-
-# Using npm
-npm install @vue-storefront/sdk
-
-# Using pnpm
-pnpm install @vue-storefront/sdk
-```
-
-Once SDK Core is installed, you can proceed to install Next.js SDK module. Enter the command below in the root of your project to install Next.js SDK module:
+To get started with the SDK within Next.js, first you have to install the `@vue-storefront/next` package. In the root of your Storefront project run:
 
 ```bash [Next.js]
 # Using yarn
@@ -228,22 +215,9 @@ That's it! You can now use VueStorefront SDK Module in your Next.js app ✨
 
 ## Installation
 
-Nuxt SDK module is based on the Vue Storefront SDK Core. In order to use the Nuxt SDK module, first you need to install the SDK Core.
+To get started with the SDK within Next.js, first you have to install and configure the `@vue-storefront/nuxt` module. 
 
-```bash [SDK Core]
-# Using yarn
-yarn add @vue-storefront/sdk
-
-# Using npm
-npm install @vue-storefront/sdk
-
-# Using pnpm
-pnpm install @vue-storefront/sdk
-```
-
-Once SDK Core is installed, you can proceed to install Nuxt SDK module. Enter the command below in the root of your project to install Nuxt SDK module:
-
-1. Add `@vue-storefront/nuxt` dependency to your project
+1. In the root of your Storefront project run:
 
 ```bash [Nuxt]
 # Using yarn

--- a/packages/storefront/packages/next/CHANGELOG.md
+++ b/packages/storefront/packages/next/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change log
+
+## 1.0.1
+
+- **[CHANGED]** Set `@vue-storefront/sdk` as a dependency instead of a peer dependency
+
+## 1.0.0
+
+- Initialized the package

--- a/packages/storefront/packages/next/package.json
+++ b/packages/storefront/packages/next/package.json
@@ -2,7 +2,7 @@
   "name": "@vue-storefront/next",
   "description": "Vue Storefront dedicated features for Next.js",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
@@ -42,6 +42,9 @@
     "test:e2e": "cd ../../shared/ && yarn test:e2e",
     "test:unit": "vitest run"
   },
+  "dependencies": {
+    "@vue-storefront/sdk": "^1.0.0"
+  },
   "devDependencies": {
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",
@@ -51,7 +54,6 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "@vue-storefront/sdk": "^1.0.0",
     "react": "^18.2.0",
     "next": "^13.4.7 || ^14.0.0"
   },

--- a/packages/storefront/packages/nuxt/CHANGELOG.md
+++ b/packages/storefront/packages/nuxt/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change log
+
+## 3.0.1
+
+- **[CHANGED]** Set `@vue-storefront/sdk` as a dependency instead of a peer dependency
+
+## 3.0.0
+
+- **[BREAKING]** Rewritten from scratch. Now the package exports a Nuxt module which allows to initialize the Vue Storefront SDK.

--- a/packages/storefront/packages/nuxt/package.json
+++ b/packages/storefront/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/nuxt",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Vue Storefront dedicated features for Nuxt",
   "license": "MIT",
   "type": "module",
@@ -27,11 +27,9 @@
     "test:watch": "vitest watch",
     "prepare": "nuxi prepare"
   },
-  "peerDependencies": {
-    "@vue-storefront/sdk": "^1.0.0"
-  },
   "dependencies": {
     "@nuxt/kit": "3.7.4",
+    "@vue-storefront/sdk": "^1.0.0",
     "knitwork": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`@vue-storefront/sdk` has been set as peerDependency and because of that the user had to install it manually. Now, when it will be a dependency of Nuxt module and Next.js package, this step will no longer be needed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
