### PR TITLE
fix: make second generic option in buildModule function optional

### DIFF
--- a/.changeset/cool-pears-count.md
+++ b/.changeset/cool-pears-count.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/sdk": patch
+---
+
+[FIXED] Make the second generic argument in the `buildModule` function optional. It's not required for the `buildModule` function to have the second argument. In some cases, when the first generic argument was provided, the second one was required.

--- a/packages/sdk/src/module/buildModule.ts
+++ b/packages/sdk/src/module/buildModule.ts
@@ -10,10 +10,10 @@ import {
 /* eslint-disable no-redeclare */
 function buildModule<
   InitializedModule extends Module,
-  Options extends ModuleOptions
+  Options extends ModuleOptions = object
 >(
   module: ModuleInitializer<InitializedModule, Options>,
-  moduleOptions?: any
+  moduleOptions?: Options
 ): InitializedModule;
 
 function buildModule<


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
