### PR TITLE
fix(ES-230): `buildModule` types in tsconfig strict mode

### DIFF
--- a/.changeset/slow-cougars-think.md
+++ b/.changeset/slow-cougars-think.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/sdk": patch
+---
+
+[FIXED] `buildModule` types in tsconfig strict mode

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,7 +12,7 @@
     "build": "rimraf lib && rollup -c",
     "dev": "rimraf lib && rollup -c -w",
     "lint": "eslint . --ext .ts",
-    "test": "yarn test:unit && yarn test:integration",
+    "test": "yarn test:unit && yarn test:integration && tsc-strict",
     "test:unit": "jest ./src/__tests__/unit -c ./jest.config.unit.ts --coverage",
     "test:integration": "jest ./src/__tests__/integration -c ./jest.config.integration.ts --runInBand --coverage",
     "prepublishOnly": "yarn build",
@@ -25,6 +25,7 @@
     "babel-cli": "^6.26.0",
     "babel-preset-node": "^5.1.1",
     "nodemon": "^2.0.20",
+    "typescript-strict-plugin": "^2.3.2",
     "ts-jest": "^29.0.2",
     "ts-node-dev": "^2.0.0"
   },

--- a/packages/sdk/src/__tests__/unit/buildModule.spec.ts
+++ b/packages/sdk/src/__tests__/unit/buildModule.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { extension1Mock } from "../__mocks__/extension1.mock";
 import module1Mock from "../__mocks__/module1.mock";
 import { buildModule } from "../../module/buildModule";
@@ -51,5 +52,29 @@ describe("[buildModule]", () => {
     };
     expect(module1Mock).toHaveBeenCalledWith({ test: true });
     expect(JSON.stringify(result)).toEqual(JSON.stringify(expected));
+  });
+
+  it("should correctly infer types in typescript's strict mode", () => {
+    const moduleWithNoOptions = () => ({ connector: {} });
+    const moduleWithOptionalOptions = (_opts?: { test: boolean }) => ({
+      connector: {},
+    });
+    const moduleWithMandatoryOptions = (_opts: { test: boolean }) => ({
+      connector: {},
+    });
+
+    buildModule(moduleWithNoOptions);
+    buildModule(moduleWithNoOptions, {}, extension1Mock);
+    buildModule(moduleWithNoOptions, {}, extension1Mock, {
+      test: true,
+    });
+    buildModule(moduleWithOptionalOptions);
+    // @ts-expect-error - should correctly infer type of options
+    buildModule(moduleWithOptionalOptions, { test: "should be boolean" });
+    buildModule(moduleWithMandatoryOptions, { test: true });
+    buildModule(moduleWithMandatoryOptions, { test: true }, extension1Mock);
+    buildModule(moduleWithMandatoryOptions, { test: true }, extension1Mock, {
+      test: true,
+    });
   });
 });

--- a/packages/sdk/src/interceptors/InterceptorsManager.ts
+++ b/packages/sdk/src/interceptors/InterceptorsManager.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { handleError } from "../error";
 import type { EventManagerInterface } from "../events/EventManager";
 import type { InterceptorType, MappedInterceptors, SDKConfig } from "../types";

--- a/packages/sdk/src/module/buildModule.ts
+++ b/packages/sdk/src/module/buildModule.ts
@@ -5,6 +5,7 @@ import {
   ModuleInitializer,
   ExtensionInitializer,
   ModuleOptions,
+  ModuleInitializerWithOptions,
 } from "../types";
 
 /* eslint-disable no-redeclare */
@@ -48,7 +49,7 @@ function buildModule<
   InitializedExtension extends Extension<InitializedModule>,
   ExtensionOptions extends ModuleOptions
 >(
-  module: ModuleInitializer<InitializedModule, Options>,
+  module: ModuleInitializerWithOptions<InitializedModule, Options>,
   moduleOptions: Options,
   extension?:
     | ExtensionInitializer<
@@ -71,7 +72,7 @@ function buildModule<
   InitializedExtension extends Extension<InitializedModule>,
   ExtensionOptions extends ModuleOptions
 >(
-  module: ModuleInitializer<InitializedModule, Options>,
+  module: ModuleInitializerWithOptions<InitializedModule, Options>,
   moduleOptions: Options,
   extension?:
     | ExtensionInitializer<

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -263,6 +263,16 @@ export type ModuleInitializer<
 > = (options?: Options) => InitializedModule;
 
 /**
+ * ModuleInitializer Type represents a function accepting module options
+ * as an argument and returning the actual module.
+ * It requires options to be passed to the module.
+ */
+export type ModuleInitializerWithOptions<
+  InitializedModule extends Module,
+  Options extends ModuleOptions
+> = (options: Options) => InitializedModule;
+
+/**
  * ExtensionInitializer Type represents a function accepting extension options
  * as an argument and returning the actual extension.
  */

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -5,7 +5,12 @@
     "outDir": "./lib",
     "declarationDir": "./lib",
     "declaration": true,
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "plugins": [
+      {
+        "name": "typescript-strict-plugin"
+      }
+    ]
   },
   "exclude": ["node_modules"],
   "include": ["src/**/*.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4371,6 +4371,14 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -13367,6 +13375,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typescript-strict-plugin@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/typescript-strict-plugin/-/typescript-strict-plugin-2.3.2.tgz#a383c483c867b8673cdf27bc21599192f454843e"
+  integrity sha512-dzD8uLjBrBpm10nrjgi5H1ZuBTr21U+gvuZ9EKHN3tHTW8N/wTCpkEiqMlfVUTtonBB+KUchxoJE3huweWYUqg==
+  dependencies:
+    chalk "^3.0.0"
+    execa "^4.0.0"
+    ora "^5.4.1"
+    yargs "^16.2.0"
 
 "typescript@^3 || ^4", typescript@^4.6.4:
   version "4.9.5"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

- [ES-230](https://vsf.atlassian.net/servicedesk/customer/portal/83/ES-230?atlOrigin=eyJpIjoiNDQyOTJjMWJlNjI0NGIxOGI5NzI0ODk1ZDlhM2M1OWIiLCJwIjoiaGFscC1zbGFjayJ9)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Fixed `buildModule` types in strict mode
- Added `[typescript-strict-plugin](https://github.com/allegro/typescript-strict-plugin)`, to be able to use strict mode partially in the package, and add tests for strict mode

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
