### PR TITLE
fix: generate changelog on postinstall

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@vue-storefront/changesets",
+  "changelog": "./changelog.js",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ coverage
 
 # Cypress generated files
 **/cypress/screenshots
+
+# Local version of changeset's changelog
+.changeset/changelog.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "lerna run lint",
     "changesets:version": "yarn changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install && yarn prepare:docs",
     "changesets:publish": "yarn build && yarn changeset publish",
-    "prepare:docs": "cd docs && yarn install && yarn api-extract && yarn add-changelogs"
+    "prepare:docs": "cd docs && yarn install && yarn api-extract && yarn add-changelogs",
+    "postinstall": "cd packages/changesets && yarn build"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -18,7 +19,6 @@
     "@types/jest": "^26.0.24",
     "@types/node": "^16",
     "@vue-storefront/api-extractor-config": "^0.0.4",
-    "@vue-storefront/changesets": "*",
     "@vue-storefront/eslint-config-integrations": "^0.0.19",
     "@vue-storefront/integrations-tsconfig": "^0.0.4",
     "@vue-storefront/jest-config": "^0.0.3",

--- a/packages/changesets/package.json
+++ b/packages/changesets/package.json
@@ -9,7 +9,8 @@
     "lib"
   ],
   "scripts": {
-    "build": "rimraf lib && rollup -c",
+    "build": "rimraf lib && rollup -c && yarn update-root-changelog",
+    "update-root-changelog": "cp ./lib/index.cjs.js ../../.changeset/changelog.js",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#7065 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Reverted #7065 - changelog package was taken as a symlink, and there was no build output
- Now `changelog.js` is generated after `yarn install`
- The instruction for other consumers of the changelog is still valid - because they will install the `@vue-storefront/changesets` package, and not use a local symlink

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
