### PR TITLE
docs: remove deleted pages from sidebar

### DIFF
--- a/docs/content/5.integrations/_sidebar.json
+++ b/docs/content/5.integrations/_sidebar.json
@@ -24,14 +24,6 @@
           {
             "title": "Creating a Custom Integration",
             "_path": "/integrations/custom/quick-start"
-          },
-          {
-            "title": "Building an API Client",
-            "_path": "/integrations/custom/api-client"
-          },
-          {
-            "title": "Building an SDK Module",
-            "_path": "/integrations/custom/sdk-module"
           }
         ]
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With the changes to the integration docs, the sidebar has to be updated. The reason that this sidebar is hardcoded is to prevent all of the `/integration/${INTEGRATION}/...` from appearing in this sidebar.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
