### PR TITLE
feat: configuration options in create server

### DIFF
--- a/.changeset/loud-ads-accept.md
+++ b/.changeset/loud-ads-accept.md
@@ -1,0 +1,34 @@
+---
+"@vue-storefront/middleware": minor
+---
+
+[ADDED] Options as a second parameter of `createServer`. This allows you to pass additional options to `cors`, `body-parser` and `cookie-parser` express middlewares.
+
+```ts
+import { createServer } from '@vue-storefront/middleware';
+import config from "../middleware.config";
+
+createServer(config, {
+  cors: {
+    origin: 'http://localhost:3000',
+    credentials: true
+  },
+  bodyParser: {
+    limit: '50mb'
+  },
+  cookieParser: {
+    secret: "secret",
+  }
+});
+```
+
+[CHANGED] `cors` middleware uses the default configuration. If you want to change it, you can pass the options as a second parameter of `createServer`. The default configuration is:
+
+```json
+{
+  "origin": "*",
+  "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
+  "preflightContinue": false,
+  "optionsSuccessStatus": 204
+}
+```

--- a/.changeset/loud-ads-accept.md
+++ b/.changeset/loud-ads-accept.md
@@ -22,13 +22,4 @@ createServer(config, {
 });
 ```
 
-[CHANGED] `cors` middleware uses the default configuration. If you want to change it, you can pass the options as a second parameter of `createServer`. The default configuration is:
-
-```json
-{
-  "origin": "*",
-  "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
-  "preflightContinue": false,
-  "optionsSuccessStatus": 204
-}
-```
+[ADDED] `http://localhost:4000` to the default cors origin.

--- a/packages/middleware/src/createServer.ts
+++ b/packages/middleware/src/createServer.ts
@@ -33,13 +33,7 @@ async function createServer<
       ? cookieParser(options.cookieParser.secret, options.cookieParser.options)
       : cookieParser()
   );
-  app.use(
-    cors(
-      options.cors ?? {
-        credentials: true,
-      }
-    )
-  );
+  app.use(cors(options.cors));
   app.disable("x-powered-by");
 
   consola.info("Middleware starting....");

--- a/packages/middleware/src/createServer.ts
+++ b/packages/middleware/src/createServer.ts
@@ -19,6 +19,11 @@ import {
   callApiFunction,
 } from "./handlers";
 
+const defaultCorsOptions: CreateServerOptions["cors"] = {
+  credentials: true,
+  origin: ["http://localhost:3000", "http://localhost:4000"],
+};
+
 async function createServer<
   TIntegrationContext extends Record<string, IntegrationContext>
 >(
@@ -33,7 +38,7 @@ async function createServer<
       ? cookieParser(options.cookieParser.secret, options.cookieParser.options)
       : cookieParser()
   );
-  app.use(cors(options.cors));
+  app.use(cors(options.cors ?? defaultCorsOptions));
   app.disable("x-powered-by");
 
   consola.info("Middleware starting....");

--- a/packages/middleware/src/types/server.ts
+++ b/packages/middleware/src/types/server.ts
@@ -1,3 +1,6 @@
+import { CorsOptions, CorsOptionsDelegate } from "cors";
+import bodyParser from "body-parser";
+import cookieParser from "cookie-parser";
 import { TObject } from "./base";
 import {
   ApiClientExtension,
@@ -115,3 +118,12 @@ export type CreateApiProxyFn = <CONFIG, API, CLIENT>(
   givenConfig: any,
   customApi?: any
 ) => ApiInstance<CONFIG, API, CLIENT>;
+
+export interface CreateServerOptions {
+  bodyParser?: bodyParser.OptionsJson;
+  cookieParser?: {
+    secret: string | string[];
+    options: cookieParser.CookieParseOptions;
+  };
+  cors?: CorsOptions | CorsOptionsDelegate;
+}

--- a/packages/middleware/src/types/server.ts
+++ b/packages/middleware/src/types/server.ts
@@ -120,10 +120,25 @@ export type CreateApiProxyFn = <CONFIG, API, CLIENT>(
 ) => ApiInstance<CONFIG, API, CLIENT>;
 
 export interface CreateServerOptions {
+  /**
+   * The options for the `express.json` middleware.
+   * If not provided, the default options will be used.
+   * @see https://www.npmjs.com/package/body-parser
+   */
   bodyParser?: bodyParser.OptionsJson;
+  /**
+   * The options for the `cookie-parser` middleware.
+   * If not provided, the default options will be used.
+   * @see https://www.npmjs.com/package/cookie-parser
+   */
   cookieParser?: {
     secret: string | string[];
     options: cookieParser.CookieParseOptions;
   };
+  /**
+   * The options for the `cors` middleware.
+   * If not provided, the default options will be used.
+   * @see https://www.npmjs.com/package/cors
+   */
   cors?: CorsOptions | CorsOptionsDelegate;
 }

--- a/packages/middleware/src/types/server.ts
+++ b/packages/middleware/src/types/server.ts
@@ -137,7 +137,13 @@ export interface CreateServerOptions {
   };
   /**
    * The options for the `cors` middleware.
-   * If not provided, the default options will be used.
+   * If not provided, the following configuration will be used:
+   * ```json
+   * {
+   *  "credentials": true,
+   *  "origin": ["http://localhost:3000", "http://localhost:4000"]
+   * }
+   * ```
    * @see https://www.npmjs.com/package/cors
    */
   cors?: CorsOptions | CorsOptionsDelegate;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- [ES-411](https://alokai.atlassian.net/browse/ES-411)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added options to `createServer` which allows to customize the `cors`, `cookieParser`, and `bodyParser` middlewares

Context:
The change is related to the _hacky_ cors config customization which we've got atm in templates. Currently, the middleware app is run mostly on port 4000, because Storefront app occupies port 3000 (default port for Next.js), so I could change the  `origin` to accept also `localhost:4000`, however there are also multistores which are run locally and other cases, when the current cors config is enough. The workaround which we do in the templates looks as follows

```ts
  const CORS_MIDDLEWARE_NAME = "corsMiddleware";

  const corsMiddleware = app._router.stack.find(
    (middleware: any) => middleware.name === CORS_MIDDLEWARE_NAME,
  );
  const multistoreUrls = listOfStoresDomains.map((storeUrl) => `https://${storeUrl}`);
  corsMiddleware.handle = cors({
    origin: [
      "https://dev.local",
      "http://localhost:3000",
      "http://localhost:3333",
      ...multistoreUrls,
    ],
    optionsSuccessStatus: 200,
    credentials: true,
  });
```

I propose to instead by default allow cors for all origins, and pass an option to configure it when calling `createServer`.

I've added also an option to pass config for `cookieParser`, and `bodyParser`, but I'm open to exclude it from this PR, because it extends our API layer.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
