### PR TITLE
chore: fix legacy docs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "build": "yarn build:core && yarn build:cache && yarn build:middleware && yarn build:nuxt-module",
-    "build:core": "cd packages/core && yarn build",
-    "build:cache": "cd packages/cache && yarn build",
-    "build:docs": "cd packages/docs && yarn build",
-    "build:middleware": "cd packages/middleware && yarn build",
-    "build:nuxt-module": "cd packages/nuxt-module && yarn build",
+    "build": "lerna run --ignore docs build",
     "cli": "cd packages/cli && yarn cli",
     "commit": "cz",
     "core:changelog": "cd packages/docs/scripts && node changelog --in ../changelog --out ../reference/changelog.md",

--- a/packages/api-extractor.base.json
+++ b/packages/api-extractor.base.json
@@ -36,6 +36,9 @@
       },
       "ae-forgotten-export": {
         "logLevel": "none"
+      },
+      "ae-wrong-input-file-type": {
+        "logLevel": "none"
       }
     },
     "tsdocMessageReporting": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "vuepress dev",
-    "build": "yarn build:core && NODE_OPTIONS=--max_old_space_size=8192 vuepress build",
+    "build": "yarn build:core && NODE_OPTIONS=\"--max_old_space_size=8192 --openssl-legacy-provider\" vuepress build",
     "core-cache-ref": "cd ../cache && api-extractor run --local",
     "core-core-ref": "cd ../core && api-extractor run --local",
     "core-middleware-ref": "cd ../middleware && api-extractor run --local",


### PR DESCRIPTION
### 🔗 Linked issue

[ES-516](https://alokai.atlassian.net/browse/ES-516)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

After adding storyblok repo to the legacy branch, legacy docs stopped building. Even though while building the /docs we do not explicitly use api extractor on storyblok, it still throws the following error:

> Error: /Users/lukaszsliwa/Documents/repo/core/vue-storefront/packages/storyblok/src/types.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error

This PR only supresses the error since I truly have no idea why it's ocurring. Nevertheless, we should take a look at this issue in the future and fix it at the root.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
