### PR TITLE
chore: change filename casing for next eslint

### DIFF
--- a/.changeset/fresh-wasps-remember.md
+++ b/.changeset/fresh-wasps-remember.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/eslint-config": patch
+---
+
+[CHANGED] Filename casing lint rule in `@vue-storefront/eslint-config/next`. From now kebab-case is preferred for filenames.

--- a/engineering-toolkit/eslint-config/src/next-strict.js
+++ b/engineering-toolkit/eslint-config/src/next-strict.js
@@ -16,8 +16,11 @@ module.exports = {
   rules: {
     // prefer `import type` https://typescript-eslint.io/rules/consistent-type-imports/
     "@typescript-eslint/consistent-type-imports": "error",
-    // enforce PascalCase for React components https://github.com/dolsem/eslint-plugin-filename-rules
-    "filename-rules/match": ["error", { ".tsx": "pascalcase" }],
+    // enforce kebab-case for file naming https://github.com/dolsem/eslint-plugin-filename-rules
+    "filename-rules/match": [
+      "error",
+      { ".ts": "kebabcase", ".tsx": "kebabcase" },
+    ],
     // sort keys in JSON files https://eslint.org/docs/latest/rules/sort-keys
     "jsonc/sort-keys": ["error"],
     // https://eslint.org/docs/latest/rules/no-restricted-imports
@@ -105,6 +108,14 @@ module.exports = {
             fixerMessage: " TODO: Add JSDoc comment",
           },
         ],
+      },
+    },
+    {
+      // allow different case for root directory files
+      excludedFiles: ["*/*"],
+      files: "*",
+      rules: {
+        "filename-rules/match": "off",
       },
     },
   ],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
With Next.js app router, most of the ecosystem is going towards kebab-case for files and directories. To align us with the ecosystem, the new rule has been added which validates that non-root files are using kebab-case.

Examples:

Next.js Repo [next.js/packages/next/src/client at canary · vercel/next.js](https://github.com/vercel/next.js/tree/canary/packages/next/src/client) 

Framework-specific file conventions for [File Conventions: default.js](https://nextjs.org/docs/app/api-reference/file-conventions/default) 

Example project maintained by Next.js Core dev. [GitHub - shadcn-ui/taxonomy: An open source application built using the new router, server components and everything new in Next.js 13.](https://github.com/shadcn-ui/taxonomy/tree/main)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
