### PR TITLE
feat: add logger module to the SDK

### DIFF
--- a/.changeset/slimy-olives-drive.md
+++ b/.changeset/slimy-olives-drive.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/sdk": minor
+---
+
+[ADDED] Logger module

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,6 +19,9 @@
     "changesets:version": "yarn changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install",
     "changesets:publish": "yarn run build && yarn changeset publish"
   },
+  "dependencies": {
+    "@vue-storefront/logger": "1.0.0-rc.0"
+  },
   "devDependencies": {
     "@types/jest": "^29.0.3",
     "@types/node": "^18.11.17",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,7 +20,7 @@
     "changesets:publish": "yarn run build && yarn changeset publish"
   },
   "dependencies": {
-    "@vue-storefront/logger": "1.0.0-rc.1"
+    "@vue-storefront/logger": "1.0.0-rc.2"
   },
   "devDependencies": {
     "@types/jest": "^29.0.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,7 +20,7 @@
     "changesets:publish": "yarn run build && yarn changeset publish"
   },
   "dependencies": {
-    "@vue-storefront/logger": "1.0.0-rc.0"
+    "@vue-storefront/logger": "1.0.0-rc.1"
   },
   "devDependencies": {
     "@types/jest": "^29.0.3",

--- a/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
+++ b/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
@@ -1,3 +1,4 @@
+import { LoggerFactory } from "@vue-storefront/logger";
 import { buildModule } from "../../../modules/buildModule";
 import { initSDK } from "../../../bootstrap";
 import { loggerModule } from "../../../modules/loggerModule";
@@ -5,7 +6,6 @@ import { loggerModule } from "../../../modules/loggerModule";
 describe("loggerModule", () => {
   it("should be able to be used as standard SDK module", async () => {
     const sdkConfig = { logger: buildModule(loggerModule) };
-
     const sdk = initSDK(sdkConfig);
 
     expect(sdk.logger).toBeDefined();
@@ -64,5 +64,14 @@ describe("loggerModule", () => {
     await sdk.logger.info("foo");
 
     expect(mock).toHaveBeenCalled();
+  });
+
+  it("should created default logger when no custom handler is passed", async () => {
+    const createSpy = jest.spyOn(LoggerFactory, "create");
+    const sdkConfig = { logger: buildModule(loggerModule) };
+
+    initSDK(sdkConfig);
+
+    expect(createSpy).toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
+++ b/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
@@ -12,6 +12,7 @@ describe("loggerModule", () => {
   });
 
   it.each([
+    "log",
     "emergency",
     "alert",
     "critical",

--- a/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
+++ b/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
@@ -32,4 +32,36 @@ describe("loggerModule", () => {
       ).toBeInstanceOf(Function);
     }
   );
+
+  it("should return a proper module", async () => {
+    const module = loggerModule();
+
+    expect(module.connector).toBeDefined();
+  });
+
+  it("should be able to pass custom handler", async () => {
+    const mock = jest.fn();
+    const customLogger = {
+      log: mock,
+      emergency: mock,
+      alert: mock,
+      critical: mock,
+      error: mock,
+      warning: mock,
+      notice: mock,
+      info: mock,
+      debug: mock,
+    };
+    const sdkConfig = {
+      logger: buildModule(loggerModule, {
+        handler: customLogger,
+      }),
+    };
+
+    const sdk = initSDK(sdkConfig);
+
+    await sdk.logger.info("foo");
+
+    expect(mock).toHaveBeenCalled();
+  });
 });

--- a/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
+++ b/packages/sdk/src/__tests__/integration/modules/loggerModule.spec.ts
@@ -1,0 +1,35 @@
+import { buildModule } from "../../../modules/buildModule";
+import { initSDK } from "../../../bootstrap";
+import { loggerModule } from "../../../modules/loggerModule";
+
+describe("loggerModule", () => {
+  it("should be able to be used as standard SDK module", async () => {
+    const sdkConfig = { logger: buildModule(loggerModule) };
+
+    const sdk = initSDK(sdkConfig);
+
+    expect(sdk.logger).toBeDefined();
+  });
+
+  it.each([
+    "emergency",
+    "alert",
+    "critical",
+    "error",
+    "warning",
+    "notice",
+    "info",
+    "debug",
+  ])(
+    "should have a function '%s' available within the logger",
+    (functionName) => {
+      const sdkConfig = { logger: buildModule(loggerModule) };
+
+      const sdk = initSDK(sdkConfig);
+
+      expect(
+        sdk.logger[functionName as keyof typeof sdk.logger]
+      ).toBeInstanceOf(Function);
+    }
+  );
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,4 +12,5 @@ const initVSFSDK = initSDK;
 
 export { initVSFSDK, initSDK, handleError, buildModule, eventManager };
 export * from "./modules/middlewareModule";
+export * from "./modules/loggerModule";
 export * from "./types";

--- a/packages/sdk/src/modules/loggerModule/index.ts
+++ b/packages/sdk/src/modules/loggerModule/index.ts
@@ -1,11 +1,8 @@
-import {
-  LoggerFactory,
-  LoggerOptions,
-  LoggerType,
-} from "@vue-storefront/logger";
+import { LoggerFactory, LoggerType } from "@vue-storefront/logger";
 import type { Module } from "../../types";
+import type { LoggerModuleConfig } from "./types";
 
-export const loggerModule = (options?: LoggerOptions) => {
+export const loggerModule = (options?: LoggerModuleConfig) => {
   const logger = LoggerFactory.create(LoggerType.ConsolaGcp, options);
 
   return {

--- a/packages/sdk/src/modules/loggerModule/index.ts
+++ b/packages/sdk/src/modules/loggerModule/index.ts
@@ -3,7 +3,8 @@ import type { Module } from "../../types";
 import type { LoggerModuleConfig } from "./types";
 
 export const loggerModule = (options?: LoggerModuleConfig) => {
-  const logger = LoggerFactory.create(LoggerType.ConsolaGcp, options);
+  const logger =
+    options?.handler ?? LoggerFactory.create(LoggerType.ConsolaGcp, options);
 
   return {
     connector: {

--- a/packages/sdk/src/modules/loggerModule/index.ts
+++ b/packages/sdk/src/modules/loggerModule/index.ts
@@ -1,0 +1,16 @@
+import {
+  LoggerFactory,
+  LoggerOptions,
+  LoggerType,
+} from "@vue-storefront/logger";
+import type { Module } from "../../types";
+
+export const loggerModule = (options?: LoggerOptions) => {
+  const logger = LoggerFactory.create(LoggerType.ConsolaGcp, options);
+
+  return {
+    connector: {
+      ...logger,
+    },
+  } satisfies Module;
+};

--- a/packages/sdk/src/modules/loggerModule/types.ts
+++ b/packages/sdk/src/modules/loggerModule/types.ts
@@ -1,4 +1,4 @@
-type LogData = string | Error;
+type LogData = unknown;
 type Metadata = Record<string, unknown>;
 type LogLevel =
   | "emergency"

--- a/packages/sdk/src/modules/loggerModule/types.ts
+++ b/packages/sdk/src/modules/loggerModule/types.ts
@@ -11,8 +11,7 @@ type LogLevel =
   | "info"
   | "debug";
 
-export interface Logger {
-  log(level: LogLevel, logData: LogData, metadata?: Metadata): void;
+export interface LoggerInterface {
   emergency(logData: LogData, metadata?: Metadata): void;
   alert(logData: LogData, metadata?: Metadata): void;
   critical(logData: LogData, metadata?: Metadata): void;
@@ -27,6 +26,6 @@ export type LoggerModuleConfig = Partial<{
   level: LogLevel;
   includeStackTrace: boolean;
   environment: Environment;
-  handler: Logger;
+  handler: LoggerInterface;
   [key: string]: any;
 }>;

--- a/packages/sdk/src/modules/loggerModule/types.ts
+++ b/packages/sdk/src/modules/loggerModule/types.ts
@@ -1,0 +1,18 @@
+import type { Environment, LogLevel } from "@vue-storefront/logger";
+
+export type LoggerModuleConfig = Partial<{
+  level: LogLevel;
+  includeStackTrace: boolean;
+  environment: Environment;
+  handler: Partial<{
+    emergency: (args: unknown) => void;
+    alert: (args: unknown) => void;
+    critical: (args: unknown) => void;
+    error: (args: unknown) => void;
+    warning: (args: unknown) => void;
+    notice: (args: unknown) => void;
+    info: (args: unknown) => void;
+    debug: (args: unknown) => void;
+  }>;
+  [key: string]: any;
+}>;

--- a/packages/sdk/src/modules/loggerModule/types.ts
+++ b/packages/sdk/src/modules/loggerModule/types.ts
@@ -1,18 +1,32 @@
-import type { Environment, LogLevel } from "@vue-storefront/logger";
+type LogData = string | Error;
+type Metadata = Record<string, unknown>;
+type Environment = "production" | "dev" | "stage" | "test";
+type LogLevel =
+  | "emergency"
+  | "alert"
+  | "critical"
+  | "error"
+  | "warning"
+  | "notice"
+  | "info"
+  | "debug";
+
+interface Logger {
+  log(level: LogLevel, logData: LogData, metadata?: Metadata): void;
+  emergency(logData: LogData, metadata?: Metadata): void;
+  alert(logData: LogData, metadata?: Metadata): void;
+  critical(logData: LogData, metadata?: Metadata): void;
+  error(logData: LogData, metadata?: Metadata): void;
+  warning(logData: LogData, metadata?: Metadata): void;
+  notice(logData: LogData, metadata?: Metadata): void;
+  info(logData: LogData, metadata?: Metadata): void;
+  debug(logData: LogData, metadata?: Metadata): void;
+}
 
 export type LoggerModuleConfig = Partial<{
   level: LogLevel;
   includeStackTrace: boolean;
   environment: Environment;
-  handler: Partial<{
-    emergency: (args: unknown) => void;
-    alert: (args: unknown) => void;
-    critical: (args: unknown) => void;
-    error: (args: unknown) => void;
-    warning: (args: unknown) => void;
-    notice: (args: unknown) => void;
-    info: (args: unknown) => void;
-    debug: (args: unknown) => void;
-  }>;
+  handler: Logger;
   [key: string]: any;
 }>;

--- a/packages/sdk/src/modules/loggerModule/types.ts
+++ b/packages/sdk/src/modules/loggerModule/types.ts
@@ -1,6 +1,5 @@
 type LogData = string | Error;
 type Metadata = Record<string, unknown>;
-type Environment = "production" | "dev" | "stage" | "test";
 type LogLevel =
   | "emergency"
   | "alert"
@@ -12,6 +11,7 @@ type LogLevel =
   | "debug";
 
 export interface LoggerInterface {
+  log(level: LogLevel, logData: LogData, metadata?: Metadata): void;
   emergency(logData: LogData, metadata?: Metadata): void;
   alert(logData: LogData, metadata?: Metadata): void;
   critical(logData: LogData, metadata?: Metadata): void;
@@ -25,7 +25,6 @@ export interface LoggerInterface {
 export type LoggerModuleConfig = Partial<{
   level: LogLevel;
   includeStackTrace: boolean;
-  environment: Environment;
   handler: LoggerInterface;
   [key: string]: any;
 }>;

--- a/packages/sdk/src/modules/loggerModule/types.ts
+++ b/packages/sdk/src/modules/loggerModule/types.ts
@@ -11,7 +11,7 @@ type LogLevel =
   | "info"
   | "debug";
 
-interface Logger {
+export interface Logger {
   log(level: LogLevel, logData: LogData, metadata?: Metadata): void;
   emergency(logData: LogData, metadata?: Metadata): void;
   alert(logData: LogData, metadata?: Metadata): void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,6 +2977,14 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@vue-storefront/logger@1.0.0-rc.1":
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@vue-storefront/logger/-/logger-1.0.0-rc.1.tgz#e27cd3f0a07c2dc6a8a46b9f8e2bd40d421f124b"
+  integrity sha512-3/XjpYMxE/2b7PeESLnFnhup9ynXYlFXwAqv6g7gpaz5u6Lya+IxH900s6nuk380KuK/CpBhgdIikTj5TMrRUg==
+  dependencies:
+    consola "^3"
+    dotenv "^16"
+
 "@vue-storefront/rollup-config@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@vue-storefront/rollup-config/-/rollup-config-0.0.6.tgz#625f4e67790f11e2b9ff2843a95fea52849effa2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,10 +2977,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vue-storefront/logger@1.0.0-rc.1":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@vue-storefront/logger/-/logger-1.0.0-rc.1.tgz#e27cd3f0a07c2dc6a8a46b9f8e2bd40d421f124b"
-  integrity sha512-3/XjpYMxE/2b7PeESLnFnhup9ynXYlFXwAqv6g7gpaz5u6Lya+IxH900s6nuk380KuK/CpBhgdIikTj5TMrRUg==
+"@vue-storefront/logger@1.0.0-rc.2":
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@vue-storefront/logger/-/logger-1.0.0-rc.2.tgz#27e2255447ce8b0804464cedcc9a2391a4ffc398"
+  integrity sha512-RN12ITIHUKB2smsP92MYsA+Uk4UGth1XzNO5FGKJ3/wNvml4aaTCl5qoCRoA7TLHy+dFt4wJj7sxRSaHeCORPQ==
   dependencies:
     consola "^3"
     dotenv "^16"


### PR DESCRIPTION
This PR is adding a logger module to the SDK. Then it will be used within `@vue-storefront/next` and `@vue-storefront/nuxt` packages.