### PR TITLE
docs: change integrations orchestration to federation

### DIFF
--- a/docs/content/2.general/1.index.md
+++ b/docs/content/2.general/1.index.md
@@ -23,7 +23,7 @@ Alokai is not just one product. **We provide an ecosystem of independent develop
 ::list{type="success"}
 - Building a scalable **Design System** with accessible components to keep consistency between different user interface elements.
 - Building a fast and reliable **storefront** that delivers excellent User Experience to your customers.
-- **Integrating third-party vendors** into your API orchestration and storefront.
+- **Integrating third-party vendors** into your integration layer and storefront.
 - **Managing infrastructure, CI/CD pipelines, and deployments** to keep the application fast and reliable even under heavy loads.
 - **Implementing engineering and architecture best practices** ensures that the project remains flexible and maintainable even on a large scale.
 - **Decoupling frontend from underlying backend systems** so you don't have to reinvest into it every time you update or change some of them. 

--- a/docs/content/2.general/3.basics/2.philosophy.md
+++ b/docs/content/2.general/3.basics/2.philosophy.md
@@ -11,7 +11,7 @@ Alokai is not just one product. **We provide an ecosystem of independent develop
 ::list{type="success"}
 - Building a scalable **Design System** with accessible components to keep consistency between different user interface elements.
 - Building a fast and reliable **storefront** that delivers excellent User Experience to your customers.
-- **Integrating third-party vendors** into your API orchestration and storefront.
+- **Integrating third-party vendors** into your integration layer and storefront.
 - **Managing infrastructure, CI/CD pipelines, and deployments** to keep the application fast and reliable even under heavy loads.
 - **Implementing engineering and architecture best practices** ensures that the project remains flexible and maintainable even on a large scale.
 ::

--- a/docs/content/2.general/3.basics/4.data-flow.md
+++ b/docs/content/2.general/3.basics/4.data-flow.md
@@ -42,7 +42,7 @@ Each API Client and method exposes hooks that allow you to change the initial co
 
 <img alt="General Data Flow" src="/img/data-flow/middleware.svg" class="mx-auto"/>
 
-:card{to="/middleware" title="Middleware" description="Middleware is an integration and orchestration layer of Alokai stack. It connects different third-party vendors and exposes one API to the Storefront (or other touchpoints) to increase performance and scalability of your application." icon="fa6-solid:layer-group"}
+:card{to="/middleware" title="Middleware" description="Middleware is an integration layer of Alokai stack. It connects different third-party vendors and exposes one API to the Storefront (or other touchpoints) to increase performance and scalability of your application." icon="fa6-solid:layer-group"}
 
 ## Using GraphQL
 

--- a/docs/content/3.middleware/2.guides/4.federation.md
+++ b/docs/content/3.middleware/2.guides/4.federation.md
@@ -1,20 +1,16 @@
-# Data Integration and Orchestration
+# Data Federation
 
-Optimizing server requests through data integration and orchestration is essential for frontend performance. This guide introduces the orchestration feature, highlighting its role in integrating extensions and streamlining frontend code.
+Optimizing server requests through data federation is a common technique used within composable architectures that improves performance and reduces coupling between frotnend and backend API's. This guide shows how to use the `getApiClient` method to retrieve and interact with integrations within the context of another integration to mix them together in one request.
 
-## Enhancing Frontend Performance through Data Orchestration
-
-Data orchestration allows for consolidating multiple server requests into a single endpoint, which significantly eases the burden on the frontend. This is particularly beneficial in scenarios involving numerous simultaneous server requests.
-
-### Advantages:
+## Why?
 
 - **Minimized Network Traffic**: Fewer server calls lead to reduced latency and enhanced responsiveness.
-- **Simplified Frontend Architecture**: By grouping related server requests, the frontend logic becomes less complex.
-- **Uniform Data Collection**: Ensures that data fetched from different sources is consistent and provided in a standard format.
+- **Simplified Frontend Architecture**: By grouping related server requests, the frontend logic becomes less complex and less coupled.
+- **Data Unification**: You can retrieve data from multiple sources and unify it in one response under common data model unrelated to the details of underlying API's.
 
-### Implementation:
+## How?
 
-## The `getApiClient` Method
+## Uisng `getApiClient` Method to access different API client
 
 If you want to retrieve a loaded integration within the context of another, you can use the `getApiClient` method. This method serves as a bridge between various integrations, ensuring seamless data flow and interaction.
 
@@ -78,13 +74,13 @@ export const integrations = {
 
 4. Return Unified Response: Send a consolidated response back to the frontend.
 
-### Using orchestration methods in the frontend
+### Using federation methods in the frontend
 
-To call the orchestration endpoint, you can follow the [Using extension methods in the frontend guide](/middleware/guides/extensions#using-extension-methods-in-the-frontend).
+To call the federation endpoint, you can follow the [Using extension methods in the frontend guide](/middleware/guides/extensions#using-extension-methods-in-the-frontend).
 
 ## Real-World Examples
 
-The examples provided demonstrate practical uses of data orchestration:
+The examples provided demonstrate practical uses of data federation:
 
 ### Example 1: Fetching Custom Product Properties from Legacy Systems
 
@@ -99,7 +95,7 @@ export const integrations = {
     extensions: (extensions) => [
       ...extensions,
       {
-        name: "orchestration-extension",
+        name: "federation-extension",
         extendApiMethods: {
           enrichedSearch: async (context, params: { productId: string }) => {
             const sapccApi = context.api;
@@ -149,11 +145,18 @@ import {
 
 :::tip Type of endpoints
 
-Sometimes, the `Endpoints` type is not exported by the integration. If that's the case, you can import the `XyzIntegrationContext` type from the integration package. For example, the `sapcc` integration exports the `SapccIntegrationContext` type, which contains the following:
+Sometimes, the `Endpoints` type is not exported by the integration. If that's the case, you can import the `{xyz}IntegrationContext` type from the integration package. 
 
-- `SapccIntegrationContext['api']` - the endpoints type
-- `SapccIntegrationContext['config']` - the configuration object type
-- `SapccIntegrationContext['client']` - the HTTP client object type
+For example, the `sapcc` integration exports the `SapccIntegrationContext` type, which contains the following:
+
+```typescript
+import { SapccIntegrationContext } from "@vsf-enterprise/sapcc-api";
+
+SapccIntegrationContext.api // the endpoints type
+SapccIntegrationContext.config // the configuration object type
+SapccIntegrationContext.client // the HTTP client object type
+
+```
 
 This applies to all integrations.  
 :::

--- a/docs/content/guides/4.customization-next-js/6.method-overriding.md
+++ b/docs/content/guides/4.customization-next-js/6.method-overriding.md
@@ -7,7 +7,7 @@ navigation:
 
 # Overriding API methods / Getting product reviews from an external source
 
-Alokai Middleware is called an orchestration layer - it's responsible for combining data from different sources and
+Alokai Middleware is called an integration layer - it's responsible for combining data from different sources and
 presenting it to the front end in a simple form. In this chapter, we will tackle a common business case - fetching reviews
 from an external system. It is a common scenario that product reviews are managed by a dedicated service rather than the
 eCommerce platform.

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,4 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   extends: ["sf-docs-base"],
+  routeRules: {
+    "/middleware/guides/orchestration": {
+      redirect: "/middleware/guides/federation",
+    },
+  },
 });
+


### PR DESCRIPTION
Use the correct naming for the data federation capability (we're not there yet with rochestration)