### PR TITLE
chore(IN-4315): remove gitguardian scan

### DIFF
--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -15,24 +15,6 @@ on:
 
 
 jobs:
-  scanning:
-    name: GitGuardian scan
-    if: false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # fetch all history so multiple commits can be scanned
-      - uses: GitGuardian/ggshield-action@v1
-        with:
-          args: -v
-        env:
-          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
-          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
-          GITHUB_PULL_BASE_SHA:  ${{ github.event.pull_request.base.sha }}
-          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
-
   run-ci:
     name: Run CI
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitGuardian action is set up automatically with GitGuardian Bot, no need for additional action (which was skipped)