### PR TITLE
Expose createExpress

### DIFF
--- a/packages/middleware/src/createServer.ts
+++ b/packages/middleware/src/createServer.ts
@@ -1,6 +1,6 @@
 import cookieParser from "cookie-parser";
 import cors from "cors";
-import express from "express";
+import express, { Express } from "express";
 import type { HelmetOptions } from "helmet";
 import helmet from "helmet";
 import http, { Server } from "node:http";
@@ -31,12 +31,12 @@ const defaultCorsOptions: CreateServerOptions["cors"] = {
   origin: ["http://localhost:3000", "http://localhost:4000"],
 };
 
-async function createServer<
+async function createExpress<
   TIntegrationContext extends Record<string, IntegrationContext>
 >(
   config: MiddlewareConfig<TIntegrationContext>,
   options: CreateServerOptions = {}
-): Promise<Server> {
+): Promise<Express> {
   const loggerManager = new LoggerManager<LoggerOptions>(
     config,
     (loggerConfig) =>
@@ -100,10 +100,20 @@ async function createServer<
     res.end("ok");
   });
 
+  logger.info("Middleware created!");
+  return app;
+}
+
+async function createServer<
+  TIntegrationContext extends Record<string, IntegrationContext>
+>(
+  config: MiddlewareConfig<TIntegrationContext>,
+  options: CreateServerOptions = {}
+): Promise<Server> {
+  const app = await createExpress(config, options);
   const server = http.createServer(app);
   createTerminus(server, createTerminusOptions(options.readinessProbes));
-  logger.info("Middleware created!");
   return server;
 }
 
-export { createServer };
+export { createServer, createExpress };


### PR DESCRIPTION
In v4 of @vue-storefront/middleware we used to get an express app from createServer

Since I self host in a complex setup I was using the express server directly instead of an http server, It was very usefull because I could also do requests to it internal to the process, which you can't with a node server

So this PR splits the createServer into createExpress and createServer so that we can still use createExpress to get the express app directly