### PR TITLE
feat: add form data handler in the sdk middleware module

### DIFF
--- a/.changeset/long-panthers-learn.md
+++ b/.changeset/long-panthers-learn.md
@@ -1,0 +1,20 @@
+---
+"@vue-storefront/sdk": minor
+---
+
+**[ADDED]** Add support for multipart/form-data requests in SDK
+
+- Added handling for multipart/form-data content type in the default HTTP client
+- Automatically handles File and Blob objects in request parameters
+
+```typescript
+// Upload a file using multipart/form-data
+await sdk.commerce.uploadFile(
+  { file: new File(["content"], "test.txt", { type: "text/plain" }) },
+  prepareConfig({
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  })
+);
+```

--- a/docs/content/3.middleware/2.guides/2.getting-started.md
+++ b/docs/content/3.middleware/2.guides/2.getting-started.md
@@ -129,7 +129,7 @@ fileUpload: (req) => ({
 
 Available options:
 
-- `enabled`: Enable/disable file upload functionality (default: `true`)
+- `enabled`: Enable/disable file upload functionality (default: `false`)
 - `maxFileSize`: Maximum file size in bytes (default: 5MB) // Maximum file size is limited to 10MB
 - `maxFiles`: Maximum number of files per upload (default: 5)
 - `allowedMimeTypes`: Array of allowed MIME types (default: `["image/*", "application/pdf"]`)
@@ -147,6 +147,8 @@ export const upload = (context) => {
   });
 };
 ```
+
+For the performance reasons, file uploads are disabled by default. It is recommended to enable them only when needed and use headers to control file upload behavior.
 
 You can also dynamically control file upload behavior on a per-request basis. This is particularly useful when you want to enable uploads only for specific scenarios, such as:
 

--- a/packages/sdk/src/__tests__/__mocks__/apiClient/server.js
+++ b/packages/sdk/src/__tests__/__mocks__/apiClient/server.js
@@ -23,6 +23,9 @@ const { createApiClient } = apiClientFactory({
     unauthorized: async (_context, _params) => {
       throw { statusCode: 401, message: "Unauthorized" };
     },
+    uploadFile: async (_context, params) => {
+      return { file: params.file };
+    },
     logout: async (_context) => {},
   },
 });

--- a/packages/sdk/src/__tests__/__mocks__/apiClient/types.ts
+++ b/packages/sdk/src/__tests__/__mocks__/apiClient/types.ts
@@ -21,4 +21,10 @@ export type Endpoints = {
    * For testing void responses.
    */
   logout: () => Promise<void>;
+  /**
+   * Upload a file.
+   */
+  uploadFile: (params: {
+    file: { name: string; content: string };
+  }) => Promise<{ file: { name: string; content: string } }>;
 };

--- a/packages/sdk/src/__tests__/integration/modules/middlewareModule.spec.ts
+++ b/packages/sdk/src/__tests__/integration/modules/middlewareModule.spec.ts
@@ -867,4 +867,56 @@ describe("middlewareModule", () => {
 
     expect(logSpy).not.toHaveBeenCalled();
   });
+
+  it("should create FormData when Content-Type is multipart/form-data", async () => {
+    const customHttpClient = jest.fn();
+    const sdkConfig = {
+      commerce: buildModule(middlewareModule<Endpoints>, {
+        apiUrl: "http://localhost:8181/commerce",
+        cdnCacheBustingId: "commit-hash",
+        httpClient: customHttpClient,
+      }),
+    };
+    const sdk = initSDK(sdkConfig);
+
+    await sdk.commerce.uploadFile(
+      { file: { name: "test.txt", content: "test" } },
+      prepareConfig({
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      })
+    );
+
+    const [url, params, config] = customHttpClient.mock.calls[0];
+    expect(url).toBe("http://localhost:8181/commerce/uploadFile");
+    expect(params[0]).toEqual({ file: { name: "test.txt", content: "test" } });
+    expect(config.headers["Content-Type"]).toBe("multipart/form-data");
+  });
+
+  it("should maintain correct endpoint URL for multipart requests", async () => {
+    const customHttpClient = jest.fn();
+    const sdkConfig = {
+      commerce: buildModule(middlewareModule<Endpoints>, {
+        apiUrl: "http://localhost:8181/commerce",
+        httpClient: customHttpClient,
+      }),
+    };
+    const sdk = initSDK(sdkConfig);
+
+    await sdk.commerce.uploadFile(
+      { file: { name: "test.txt", content: "test" } },
+      prepareConfig({
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      })
+    );
+
+    expect(customHttpClient).toHaveBeenCalledWith(
+      "http://localhost:8181/commerce/uploadFile",
+      expect.any(Array),
+      expect.any(Object)
+    );
+  });
 });


### PR DESCRIPTION
**Summary**
The issue involves enhancing the middleware express app by allowing the addition of multiple body parsers. Currently, only the JSON body parser is available, which limits functionality for developers needing to implement file uploads.

**Context**
The middleware express app is currently configured to use only a JSON body parser. This restriction poses challenges for developers who require different body parsers for specific functionalities, such as file uploads.

SDK piece was required to properly send form data.