### PR TITLE
chore(ES-1457): mention readinessProbes config requirement in middleware changelog

### DIFF
--- a/packages/middleware/CHANGELOG.md
+++ b/packages/middleware/CHANGELOG.md
@@ -103,7 +103,20 @@ If you're using that older template, please change the `Express` type to `Server
 - async function runMiddleware(app: Express) {
 ```
 
-- [ADDED] New GET /readyz endpoint for middleware for using with Kubernetes readiness probes. Please see https://docs.alokai.com/middleware/guides/readiness-probes for more information
+- [ADDED] New GET /readyz endpoint for middleware for using with Kubernetes readiness probes. Please see https://docs.alokai.com/middleware/guides/readiness-probes for more information. For the endpoint to work correctly, it is required to pass `readinessProbes` configuration (at least an empty array) to `createServer()`:
+
+```diff
+// ./apps/storefront-middleware/src/index.ts
+import { createServer, type CreateServerOptions } from "@vue-storefront/middleware";
+
+async function runApp() {
+  const app = await createServer(config, {
+    cors: process.env.NODE_ENV === "production" ? undefined : developmentCorsConfig,
++   readinessProbes: [] 
+  });
+}
+
+```
 
 ## 4.3.1
 


### PR DESCRIPTION
For the `/readyz` endpoint to work correctly in `@vue-storefront/middleware` before version `5.3.2`, one must pass the `readinessProbes: []` configuration to `createServer` in `./apps/storefront-middleware/src/index.ts`. This PR mentions this requirement in the package's changelog as requested by @vladovsiienko 