### PR TITLE
poc: processHeaders handler

### DIFF
--- a/packages/middleware/src/createServer.ts
+++ b/packages/middleware/src/createServer.ts
@@ -22,6 +22,7 @@ import {
   prepareArguments,
   callApiFunction,
   validateParams,
+  processHeaders,
 } from "./handlers";
 import { createTerminusOptions } from "./terminus";
 import { prepareLogger } from "./handlers/prepareLogger";
@@ -89,6 +90,7 @@ async function createServer<
   app.all(
     "/:integrationName/:extensionName?/:functionName",
     validateParams(integrations),
+    processHeaders,
     prepareFileUpload(options),
     prepareLogger(loggerManager),
     prepareApiFunction(integrations),

--- a/packages/middleware/src/handlers/index.ts
+++ b/packages/middleware/src/handlers/index.ts
@@ -4,3 +4,4 @@ export * from "./prepareErrorHandler";
 export * from "./prepareArguments";
 export * from "./prepareLogger";
 export * from "./validateParams";
+export * from "./processHeaders";

--- a/packages/middleware/src/handlers/processHeaders/index.ts
+++ b/packages/middleware/src/handlers/processHeaders/index.ts
@@ -1,0 +1,10 @@
+import type { Request, Response, NextFunction } from "express";
+
+export function processHeaders(req: Request, res: Response, next: NextFunction) {
+  const locale = req.headers['x-alokai-locale'];
+  console.log(req.cookies)
+  req.cookies['vsf-locale'] = locale;
+
+  next();
+};
+


### PR DESCRIPTION
a PoC to address issue with set-cookie headers in CDN implementation - added handler modifies all request that comes through the middleware app and replace `x-alokai-locale` header with `vsf-locale` cookie.