### PR TITLE
fix(es-1464): fix cli module import error

### DIFF
--- a/.changeset/tasty-plants-hug.md
+++ b/.changeset/tasty-plants-hug.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/cli": patch
+---
+
+[FIXED] Added back missing i18next infrastructure file to fix CLI error.

--- a/packages/cli/src/infrastructures/i18next.ts
+++ b/packages/cli/src/infrastructures/i18next.ts
@@ -1,0 +1,18 @@
+import path from "path";
+import i18next from "i18next";
+import Backend from "i18next-fs-backend";
+import getLocale from "os-locale";
+
+export const setupI18Next = async (): Promise<void> => {
+  await i18next.use(Backend).init({
+    backend: {
+      loadPath: path.resolve(__dirname, "../../locales/{{lng}}/{{ns}}.json"),
+    },
+    fallbackLng: "en-US",
+    interpolation: {
+      // Escaping is only required to prevent XSS attacks in the front-end
+      escapeValue: false,
+    },
+    lng: await getLocale(),
+  });
+};


### PR DESCRIPTION
[ES-1464](https://alokai.atlassian.net/jira/servicedesk/projects/ES/queues/custom/631/ES-1464)

---
"@vue-storefront/cli": patch
---

[FIXED] Added back missing i18next infrastructure file to fix CLI error.


[ES-1464]: https://alokai.atlassian.net/browse/ES-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ