### PR TITLE
chore(in-4476): update axios in sdk request sender

### DIFF
--- a/.changeset/rare-lemons-peel.md
+++ b/.changeset/rare-lemons-peel.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/sdk-axios-request-sender": patch
+---
+
+[CHANGED] Bumped `axios` version to `^0.29.0` and moved it from `devDependencies` to `dependencies`.

--- a/packages/sdk-axios-request-sender/package.json
+++ b/packages/sdk-axios-request-sender/package.json
@@ -14,8 +14,8 @@
     "lint": "eslint . --ext .ts,.js",
     "prepublish": "yarn build"
   },
-  "devDependencies": {
-    "axios": "^0.27.2"
+  "dependencies": {
+    "axios": "^0.29.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
[IN-4476](https://alokai.atlassian.net/browse/IN-4476)

The `@vue-storefront/sdk-axios-request-sender` exports a class constructor that expects arguments typed using interfaces imported from `axios`. Therefore, it should be a `dependency` rather than `devDependency`.

[IN-4476]: https://alokai.atlassian.net/browse/IN-4476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ