### PR TITLE
chore: adjust license to BSD-3-Clause in package.json for package sdk and middleware

### DIFF
--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "files": [
     "lib"
   ],

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/sdk",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "version": "3.4.1",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",


### PR DESCRIPTION
Hey everyone ✋ 

We just noticed that your npm packages `@vue-storefront/sdk` and `@vue-storefront/middleware`still show MIT as license but the LICENSE.md uses the BSD-3-Clause license.

If this is intended, you can close this pr :)
