### PR TITLE
fix: multibrand docs deployment link

### DIFF
--- a/docs/content/guides/7.multistore/2.tooling-and-concepts/3.deployment/7.configuration.md
+++ b/docs/content/guides/7.multistore/2.tooling-and-concepts/3.deployment/7.configuration.md
@@ -231,7 +231,7 @@ For security reasons, you must never commit credentials to version control, shar
 Learn how to set up automated deployments using CI/CD pipelines, ensuring consistent and reliable deployments across your stores.
 
 #cta
-:::docs-arrow-link{to="/guides/multistore/tooling-and-concepts/cd"}
+:::docs-arrow-link{to="/guides/multistore/tooling-and-concepts/deployment/cd"}
 Next
 :::
 ::


### PR DESCRIPTION
Small fix for an improper link

[working link](https://github.com/vuestorefront/vue-storefront/blob/37e654cc7dea39495f1949771b504e591fba1cb2/docs/content/guides/7.multistore/2.tooling-and-concepts/3.deployment/6.deployment.md?plain=1#L149) for reference